### PR TITLE
feat: add producer backpressure and cancellation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,12 @@ semantic, persistence format, or consumer lifecycle.
   `MemoryBufferQueueOptions.BoundedCapacity`.
 - A memory segment may be recycled only after every consumer group has advanced past it. A slow group must never lose
   unread data.
-- `ProduceAsync` throws `BufferQueueFullException` when a bounded queue is full; `TryProduceAsync` returns
-  `false`.
+- `MemoryBufferQueueOptions.FullMode` defaults to `Wait`: `ProduceAsync` asynchronously waits with cancellation support
+  when a bounded queue has no capacity. `Fail` throws `BufferQueueFullException` immediately. `TryProduceAsync` never
+  waits for bounded capacity and returns `false` when admission is unavailable.
+- Batch admission is all-or-nothing. In `Wait` mode, `ProduceAsync` waits for the complete batch, and a batch larger
+  than the configured capacity is invalid. Capacity is released when the minimum committed position across all known
+  consumer groups advances, including partial segments.
 
 ### MemoryMappedFile
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The project includes BenchmarkDotNet benchmarks that compare BufferQueue in Memo
 
 Summary:
 
-- Producing one item at a time: BufferQueue in Memory mode is close to `Channel<T>` under the recorded parameters. Its elapsed time is about `16%` higher in Unbounded mode and `22%` higher in Bounded mode.
-- Producing `ReadOnlyMemory<T>` batches: Memory mode is about `3.17x` faster than its single-item path in Unbounded mode and `3.43x` faster in Bounded mode. This narrow workload is also about `2.73x` and `2.82x` faster than `Channel<T>`, respectively.
+- Producing one item at a time: BufferQueue in Memory mode is close to `Channel<T>` under the recorded parameters. Its elapsed time is about `16%` higher in Unbounded mode and `19%` higher in Bounded mode.
+- Producing `ReadOnlyMemory<T>` batches: Memory mode is about `3.22x` faster than its single-item path in Unbounded mode and `3.52x` faster in Bounded mode. This narrow workload is also about `2.78x` and `2.95x` faster than `Channel<T>`, respectively.
 - Consuming: BufferQueue is optimized for batch consumption. It is faster than `Channel<T>` from `BatchSize = 1` through `1000` in this benchmark set, with a clearer advantage at larger batches and a maximum of about `103x` under the recorded parameters.
 - Memory allocation: BufferQueue allocates less in producing scenarios; `Channel<T>` allocates less in consuming scenarios.
 
@@ -50,6 +50,10 @@ Both producing and consuming benchmarks use `int` messages: the 8,192 integers f
 this sequence across `12` concurrent tasks. The single-item path loops over each task's chunk; the batch path passes
 that chunk once through `producer.ProduceAsync(chunk.AsMemory())`. The consuming benchmarks prefill the queues with
 the same sequence before measurement begins.
+
+The Bounded BufferQueue producer rows use the default `Wait` mode with capacity equal to `MessageSize`. They measure
+the capacity-available admission path and do not include time spent waiting for a full queue. These producer results
+cover Memory mode only; MemoryMappedFile production was not run for this comparison.
 
 `IterationSetup` is outside the measured operation, which only drains the queues concurrently. Channel calls
 `TryRead` for each item, while BufferQueue returns up to `BatchSize` items at a time with
@@ -71,8 +75,8 @@ Producing:
 
 | Mode | `MessageSize` | `Producers` | `Channel<T>` Mean | BufferQueue single-item Mean | BufferQueue `ReadOnlyMemory<T>` batch Mean | Result |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| Unbounded | 8192 | 12 | `288.6 μs` | `335.7 μs` | `105.9 μs` | Batch is `3.17x` faster than single-item and `2.73x` faster than `Channel<T>` |
-| Bounded | 8192 | 12 | `298.7 μs` | `363.4 μs` | `105.9 μs` | Batch is `3.43x` faster than single-item and `2.82x` faster than `Channel<T>` |
+| Unbounded | 8192 | 12 | `284.6 μs` | `328.8 μs` | `102.2 μs` | Batch is `3.22x` faster than single-item and `2.78x` faster than `Channel<T>` |
+| Bounded | 8192 | 12 | `302.4 μs` | `359.8 μs` | `102.4 μs` | Batch is `3.52x` faster than single-item and `2.95x` faster than `Channel<T>` |
 
 Consuming:
 
@@ -171,6 +175,8 @@ BufferQueue supports two consumption modes: pull mode and push mode.
 Memory mode stores data in process memory. It supports optional bounded capacity.
 
 ```csharp
+using BufferQueue.Memory;
+
 builder.Services.AddBufferQueue(bufferOptionsBuilder =>
 {
     bufferOptionsBuilder
@@ -196,6 +202,7 @@ builder.Services.AddBufferQueue(bufferOptionsBuilder =>
                     options.PartitionNumber = 8;
                     // You can set the maximum capacity of the buffer
                     options.BoundedCapacity = 100_000;
+                    options.FullMode = BufferQueueFullMode.Wait;
                 });
         })
         // Add push mode consumers,
@@ -491,8 +498,13 @@ There are two ways to obtain a Producer:
   `[FromKeyedServices("topic-name")]`.
 - If the topic is selected at runtime, inject `IBufferQueue` and call `GetProducer<T>(topicName)`.
 
-In Memory mode, if bounded capacity is set, when the buffer is full, the ProduceAsync method will discard the data and throw a BufferQueueFullException.
-You can use the TryProduceAsync method to check if the data was successfully sent.
+In Memory mode, `FullMode` defaults to `Wait` for bounded topics: `ProduceAsync` asynchronously
+waits until capacity becomes available. Pass a `CancellationToken` so that backpressure can be
+canceled. Set `FullMode` to `Fail` when immediate rejection is required; `ProduceAsync` then throws
+`BufferQueueFullException`. `TryProduceAsync` never waits for bounded capacity and returns `false`
+immediately when the item or complete batch cannot be admitted. Batch admission is all-or-nothing;
+in `Wait` mode, the producer waits for the entire batch, and a batch larger than the configured
+capacity is invalid.
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -507,14 +519,14 @@ public class TestController(
     [HttpPost("foo1")]
     public async Task<IActionResult> PostFoo1([FromBody] Foo foo)
     {
-        await foo1Producer.ProduceAsync(foo);
+        await foo1Producer.ProduceAsync(foo, HttpContext.RequestAborted);
         return Ok();
     }
 
     [HttpPost("foo2")]
     public async Task<IActionResult> PostFoo2([FromBody] Foo foo)
     {
-        await foo2Producer.ProduceAsync(foo);
+        await foo2Producer.ProduceAsync(foo, HttpContext.RequestAborted);
         return Ok();
     }
 
@@ -522,9 +534,9 @@ public class TestController(
     public async Task<IActionResult> PostBar([FromBody] Bar bar)
     {
         var producer = bufferQueue.GetProducer<Bar>("topic-bar");
-        await producer.ProduceAsync(bar);
+        await producer.ProduceAsync(bar, HttpContext.RequestAborted);
         // TryProduceAsync will return a boolean indicating whether the data was successfully sent.
-        // bool success = await producer.TryProduceAsync(bar);
+        // bool success = await producer.TryProduceAsync(bar, HttpContext.RequestAborted);
         return Ok();
     }
 }
@@ -532,9 +544,16 @@ public class TestController(
 
 ### Batch production
 
-`IBufferProducer<T>` exposes `TryProduceAsync` for a single item and a pre-buffered
-`ReadOnlyMemory<T>` batch. `BufferProducerExtensions` supplies the same-name `ProduceAsync` forms and the
-`IEnumerable<T>` convenience overloads. A non-array sequence is materialized before it invokes the core batch method.
+`IBufferProducer<T>` exposes four core methods, each accepting an optional `CancellationToken`:
+
+- `TryProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
+- `ProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
+
+`BufferProducerExtensions` provides only the `IEnumerable<T>` convenience overloads, which also accept a
+cancellation token. A non-array sequence is materialized before it invokes the core batch method. The core
+`ProduceAsync` methods are interface methods, not extensions.
 
 ```csharp
 Order[] orders = GetOrders();
@@ -550,8 +569,11 @@ if (!await producer.TryProduceAsync(orders.AsMemory()))
 
 Routing remains per item. A round-robin batch advances once for every item, and a partition-key batch applies its
 selector to every item, so one batch can write to multiple partitions. On a bounded Memory topic, when the available
-capacity cannot admit the complete batch, `TryProduceAsync` returns `false` and `ProduceAsync` throws before any item
-from that batch is appended.
+capacity cannot admit the complete batch, `TryProduceAsync` returns `false` without waiting and `ProduceAsync` either
+throws in `Fail` mode or waits for the entire batch in `Wait` mode before appending any item. The capacity limit is
+shared by all partitions. Each partition returns capacity as the minimum committed position across all known consumer
+groups advances, including within a segment. A consumer group created later starts at the current logical earliest
+position and cannot read records whose capacity has already been released.
 
 ## Samples
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,8 +33,8 @@ BufferQueue 当前提供两种存储模式：
 
 结果摘要：
 
-- 单条写入：在本次测试配置下，BufferQueue Memory 模式的写入性能接近 `Channel<T>`。Unbounded 和 Bounded 模式的耗时分别高约 `16%` 和 `22%`。
-- `ReadOnlyMemory<T>` 批量写入：Memory 模式在 Unbounded 下比单条路径快约 `3.17x`，在 Bounded 下快约 `3.43x`；在本次测试配置下，也分别比 `Channel<T>` 快约 `2.73x` 和 `2.82x`。
+- 单条写入：在本次测试配置下，BufferQueue Memory 模式的写入性能接近 `Channel<T>`。Unbounded 和 Bounded 模式的耗时分别高约 `16%` 和 `19%`。
+- `ReadOnlyMemory<T>` 批量写入：Memory 模式在 Unbounded 下比单条路径快约 `3.22x`，在 Bounded 下快约 `3.52x`；在本次测试配置下，也分别比 `Channel<T>` 快约 `2.78x` 和 `2.95x`。
 - 消费：BufferQueue 的主要优势在批量消费；本组测试从 `BatchSize = 1` 到 `1000` 均快于 `Channel<T>`，批量越大优势越明显，该次记录参数下最高约快 `103x`。
 - 内存分配：生产场景 BufferQueue 分配较少；消费场景 `Channel<T>` 分配较少。
 
@@ -47,6 +47,9 @@ BufferQueue 当前提供两种存储模式：
 `MessageSize = 8192` 表示消息条数，而非单条消息的字节大小。生产测试将这组整数分为 `12` 份，交由
 `12` 个并发任务写入：单条路径逐个遍历各自的分片；批量路径则对每个分片仅调用一次
 `producer.ProduceAsync(chunk.AsMemory())`。消费测试会在计时前将同一组整数预先写入待测队列。
+
+Bounded 的 BufferQueue 生产测试使用默认的 `Wait` 模式，容量与 `MessageSize` 相同。这里测量的是容量充足时
+的接纳路径，不包含队列写满后的等待时间。本组生产结果仅覆盖 Memory 模式，没有运行 MemoryMappedFile 写入测试。
 
 `IterationSetup` 不计入测量，测量范围只包含并发排空队列：Channel 使用 `TryRead` 逐条读取，
 BufferQueue 按 `BatchSize` 批量返回并启用 Auto Commit，不包含逐条业务处理。`BatchSize` 只作用于
@@ -66,8 +69,8 @@ MemoryMappedFile queue 对比使用 `MessageSize = 1024` 和 short-run job，
 
 | 模式 | `MessageSize` | `Producers` | `Channel<T>` Mean | BufferQueue 单条 Mean | BufferQueue `ReadOnlyMemory<T>` 批量 Mean | 结论 |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| Unbounded | 8192 | 12 | `288.6 μs` | `335.7 μs` | `105.9 μs` | 批量比单条快 `3.17x`，比 `Channel<T>` 快 `2.73x` |
-| Bounded | 8192 | 12 | `298.7 μs` | `363.4 μs` | `105.9 μs` | 批量比单条快 `3.43x`，比 `Channel<T>` 快 `2.82x` |
+| Unbounded | 8192 | 12 | `284.6 μs` | `328.8 μs` | `102.2 μs` | 批量比单条快 `3.22x`，比 `Channel<T>` 快 `2.78x` |
+| Bounded | 8192 | 12 | `302.4 μs` | `359.8 μs` | `102.4 μs` | 批量比单条快 `3.52x`，比 `Channel<T>` 快 `2.95x` |
 
 消费性能：
 
@@ -162,6 +165,8 @@ BufferQueue 支持两种消费模式：pull 模式和 push 模式。
 Memory 模式把数据保存在进程内存中，并支持可选的有界容量。
 
 ```csharp
+using BufferQueue.Memory;
+
 builder.Services.AddBufferQueue(bufferOptionsBuilder =>
 {
     bufferOptionsBuilder
@@ -187,6 +192,7 @@ builder.Services.AddBufferQueue(bufferOptionsBuilder =>
                     options.PartitionNumber = 8;
                     // 可以设置缓冲区的最大容量
                     options.BoundedCapacity = 100_000;
+                    options.FullMode = BufferQueueFullMode.Wait;
                 });
         })
         // 添加 push 模式的消费者
@@ -474,8 +480,11 @@ Producer 示例：
 - 在声明依赖时 topic 已固定：使用 `[FromKeyedServices("topic-name")]` 注入 `IBufferProducer<T>`。
 - topic 需要在运行时确定：注入 `IBufferQueue`，再调用 `GetProducer<T>(topicName)` 获取 Producer。
 
-在 Memory 模式下，配置 `BoundedCapacity` 后，如果队列已满，`ProduceAsync` 会拒绝本次写入并抛出
-`BufferQueueFullException`。需要自行处理写入失败时，可改用 `TryProduceAsync` 检查返回值。
+在 Memory 模式下，有界 topic 的 `FullMode` 默认为 `Wait`：容量不足时，`ProduceAsync` 会异步等待，直到
+容量可用。生产代码应传入 `CancellationToken`，以便取消背压等待。需要立即拒绝写入时，可将 `FullMode`
+设为 `Fail`；此时 `ProduceAsync` 会抛出 `BufferQueueFullException`。`TryProduceAsync` 永远不会等待有界容量，
+单条数据或整个批次无法接纳时会立即返回 `false`。批量接纳必须整批完成；在 `Wait` 模式下，Producer 会等待
+整个批次，且大于配置容量的批次属于无效参数。
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;
@@ -490,14 +499,14 @@ public class TestController(
     [HttpPost("foo1")]
     public async Task<IActionResult> PostFoo1([FromBody] Foo foo)
     {
-        await foo1Producer.ProduceAsync(foo);
+        await foo1Producer.ProduceAsync(foo, HttpContext.RequestAborted);
         return Ok();
     }
 
     [HttpPost("foo2")]
     public async Task<IActionResult> PostFoo2([FromBody] Foo foo)
     {
-        await foo2Producer.ProduceAsync(foo);
+        await foo2Producer.ProduceAsync(foo, HttpContext.RequestAborted);
         return Ok();
     }
 
@@ -505,9 +514,9 @@ public class TestController(
     public async Task<IActionResult> PostBar([FromBody] Bar bar)
     {
         var producer = bufferQueue.GetProducer<Bar>("topic-bar");
-        await producer.ProduceAsync(bar);
+        await producer.ProduceAsync(bar, HttpContext.RequestAborted);
         // TryProduceAsync 会返回一个布尔值，表示数据是否成功发送
-        // bool success = await producer.TryProduceAsync(bar);
+        // bool success = await producer.TryProduceAsync(bar, HttpContext.RequestAborted);
         return Ok();
     }
 }
@@ -515,9 +524,16 @@ public class TestController(
 
 ### 批量写入
 
-`IBufferProducer<T>` 的核心接口提供单条数据和 `ReadOnlyMemory<T>` 两种 `TryProduceAsync` 写入方式。
-`BufferProducerExtensions` 在此基础上提供对应的 `ProduceAsync` 重载，以及接收 `IEnumerable<T>` 的
-`ProduceAsync` 和 `TryProduceAsync` 便捷重载。传入的序列不是数组时，会先物化为数组，再进入核心批量写入路径。
+`IBufferProducer<T>` 的核心接口提供四个方法，每个方法都接收可选的 `CancellationToken`：
+
+- `TryProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
+- `ProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
+
+`BufferProducerExtensions` 只提供接收 `IEnumerable<T>` 的便捷重载，这些重载同样接收 `CancellationToken`。
+传入的序列不是数组时，会先物化为数组，再进入核心批量写入路径。核心 `ProduceAsync` 方法属于接口本身，
+不是扩展方法。
 
 ```csharp
 Order[] orders = GetOrders();
@@ -533,7 +549,10 @@ if (!await producer.TryProduceAsync(orders.AsMemory()))
 
 路由仍以单条数据为单位：Round-robin 每写入一条数据都会向前轮转一次；PartitionKey 会为批次中的每条数据
 调用 selector。因此，一个批次可以写入多个 partition。对于有界容量的 Memory 队列，剩余容量不足以容纳整个批次时，
-`TryProduceAsync` 返回 `false`，`ProduceAsync` 抛出异常；两者都不会写入该批次中的任何一条数据。
+`TryProduceAsync` 不等待并返回 `false`；`ProduceAsync` 在 `Fail` 模式下抛出异常，在 `Wait` 模式下等待整个批次，
+然后才写入数据。两者都不会写入部分批次。容量上限由 topic 下的所有 partition 共享；每个 partition 会在所有
+已知 consumer group 的最小 committed position 向前推进时归还容量，包括只推进到 segment 中间位置的情况。
+较晚创建的 consumer group 会从当前逻辑上的最早位置开始消费，无法读取容量已经释放的数据。
 
 ## 示例项目
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -42,7 +42,8 @@ Choose producer access based on when the topic is known:
 public sealed class FooPublisher(
     [FromKeyedServices("topic-foo")] IBufferProducer<Foo> producer)
 {
-    public ValueTask PublishAsync(Foo item) => producer.ProduceAsync(item);
+    public ValueTask PublishAsync(Foo item, CancellationToken cancellationToken = default) =>
+        producer.ProduceAsync(item, cancellationToken);
 }
 
 var producer = bufferQueue.GetProducer<Foo>("topic-foo");
@@ -70,33 +71,39 @@ name.
 
 ### Batch Production
 
-`IBufferProducer<T>` keeps the implementation contract to the two write attempts:
+`IBufferProducer<T>` owns the four core write methods. Each accepts an optional
+`CancellationToken`:
 
-- `ValueTask<bool> TryProduceAsync(T item)`
-- `ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items)`
+- `ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
+- `ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `ValueTask ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
 
-`BufferProducerExtensions` provides the convenience surface:
+`BufferProducerExtensions` keeps only the `IEnumerable<T>` convenience overloads:
 
-- `ValueTask ProduceAsync(T item)`
-- `ValueTask ProduceAsync(ReadOnlyMemory<T> items)`
-- `ValueTask ProduceAsync(IEnumerable<T> items)`
-- `ValueTask<bool> TryProduceAsync(IEnumerable<T> items)`
+- `ValueTask ProduceAsync(IEnumerable<T> items, CancellationToken cancellationToken = default)`
+- `ValueTask<bool> TryProduceAsync(IEnumerable<T> items, CancellationToken cancellationToken = default)`
 
 ~~~csharp
+CancellationToken cancellationToken = default;
 ReadOnlyMemory<Foo> bufferedItems = pendingItems.AsMemory();
 
-await producer.ProduceAsync(bufferedItems);
-var accepted = await producer.TryProduceAsync(bufferedItems);
+await producer.ProduceAsync(bufferedItems, cancellationToken);
+var accepted = await producer.TryProduceAsync(bufferedItems, cancellationToken);
 
 IEnumerable<Foo> itemsFromAnEnumerable = GetPendingItems();
-await producer.ProduceAsync(itemsFromAnEnumerable);
+await producer.ProduceAsync(itemsFromAnEnumerable, cancellationToken);
 ~~~
 
 Use `ReadOnlyMemory<T>` when the source is already contiguous or can be supplied as memory. It
 is the allocation-conscious core attempt because it avoids the input materialization required by a
 non-array `IEnumerable<T>` form. The `IEnumerable<T>` overload is a convenience API and materializes
-a non-array input before dispatching the batch. The non-try extensions translate a `false` result into the
-normal full-queue exception.
+a non-array input before dispatching the batch. The core `ProduceAsync` methods are not extensions;
+they define the normal write behavior for each storage mode.
+
+Cancellation is checked before a write starts and while a Memory `Wait` write is waiting for
+capacity. Once a batch has been admitted and append begins, the token is not polled between items;
+cancellation therefore cannot stop the batch halfway through.
 
 Batch production is a core producer capability. Storage-specific batch admission, routing, and
 persistence behavior is described in the related design notes.

--- a/docs/design/architecture.zh-CN.md
+++ b/docs/design/architecture.zh-CN.md
@@ -40,7 +40,8 @@ BufferQueue 是一个面向 .NET 的、按 topic 划分的强类型缓冲队列�
 public sealed class FooPublisher(
     [FromKeyedServices("topic-foo")] IBufferProducer<Foo> producer)
 {
-    public ValueTask PublishAsync(Foo item) => producer.ProduceAsync(item);
+    public ValueTask PublishAsync(Foo item, CancellationToken cancellationToken = default) =>
+        producer.ProduceAsync(item, cancellationToken);
 }
 
 var producer = bufferQueue.GetProducer<Foo>("topic-foo");
@@ -67,31 +68,36 @@ var consumer = bufferQueue.CreatePullConsumer<Foo>(new BufferPullConsumerOptions
 
 ### 批量写入
 
-`IBufferProducer<T>` 只定义两个不抛异常的核心写入方法：
+`IBufferProducer<T>` 自身定义四个核心写入方法，每个方法都接收可选的
+`CancellationToken`：
 
-- `ValueTask<bool> TryProduceAsync(T item)`
-- `ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items)`
+- `ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
+- `ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default)`
+- `ValueTask ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default)`
 
-`BufferProducerExtensions` 在此基础上提供常用的便利 API：
+`BufferProducerExtensions` 只保留接收 `IEnumerable<T>` 的便捷重载：
 
-- `ValueTask ProduceAsync(T item)`
-- `ValueTask ProduceAsync(ReadOnlyMemory<T> items)`
-- `ValueTask ProduceAsync(IEnumerable<T> items)`
-- `ValueTask<bool> TryProduceAsync(IEnumerable<T> items)`
+- `ValueTask ProduceAsync(IEnumerable<T> items, CancellationToken cancellationToken = default)`
+- `ValueTask<bool> TryProduceAsync(IEnumerable<T> items, CancellationToken cancellationToken = default)`
 
 ~~~csharp
+CancellationToken cancellationToken = default;
 ReadOnlyMemory<Foo> bufferedItems = pendingItems.AsMemory();
 
-await producer.ProduceAsync(bufferedItems);
-var accepted = await producer.TryProduceAsync(bufferedItems);
+await producer.ProduceAsync(bufferedItems, cancellationToken);
+var accepted = await producer.TryProduceAsync(bufferedItems, cancellationToken);
 
 IEnumerable<Foo> itemsFromAnEnumerable = GetPendingItems();
-await producer.ProduceAsync(itemsFromAnEnumerable);
+await producer.ProduceAsync(itemsFromAnEnumerable, cancellationToken);
 ~~~
 
 数据已经连续存储，或可以直接表示为内存区间时，应优先使用 `ReadOnlyMemory<T>`。这是核心批量写入形式，
 可以避免非数组 `IEnumerable<T>` 在提交前所需的物化。`IEnumerable<T>` 重载用于方便调用；当输入不是数组时，
-会先物化为数组，再提交整个批次。非 `Try` 扩展会在核心方法返回 `false` 时抛出 `BufferQueueFullException`。
+会先物化为数组，再提交整个批次。核心 `ProduceAsync` 方法不是扩展方法；它们定义各存储模式的正常写入行为。
+
+写入开始前会检查取消；Memory 写入因 `Wait` 等待容量时，也可以通过 token 取消。整批数据完成接纳并开始 append
+后，不会在每条数据之间反复检查 token，因此取消不会让一个批次只写入一部分。
 
 批量写入是 Producer 的核心能力。不同存储模式下的容量检查、路由和持久化行为，参见对应的设计文档。
 

--- a/docs/design/memory-mapped-file.md
+++ b/docs/design/memory-mapped-file.md
@@ -25,6 +25,12 @@ within a partition, not across all partitions. The selected partition-key routin
 `PartitionNumber` must stay compatible across restarts; see
 [Partitioning and concurrency](partitioning-and-concurrency.md).
 
+MMF implements the same four `IBufferProducer<T>` core methods as Memory storage, and every
+method accepts an optional `CancellationToken`. It is unbounded, so neither `TryProduceAsync`
+nor `ProduceAsync` waits for capacity and there is no `BufferQueueFullMode` option. The
+`IEnumerable<T>` batch convenience overloads remain extensions and materialize non-array
+inputs before calling the core `ReadOnlyMemory<T>` methods.
+
 ## Directory Layout
 
 Each topic partition is stored under:

--- a/docs/design/memory-mapped-file.zh-CN.md
+++ b/docs/design/memory-mapped-file.zh-CN.md
@@ -23,6 +23,11 @@ MMF 不支持有界容量，也不协调多个进程的 writer。它保证单个
 全局顺序。持久化 topic 在重启前后必须保持兼容的 PartitionKey 路由行为和
 `PartitionNumber`；参见 [Partition 与并发](partitioning-and-concurrency.zh-CN.md)。
 
+MMF 与 Memory 存储一样实现 `IBufferProducer<T>` 的四个核心方法，每个方法都接收可选的
+`CancellationToken`。MMF 是无界的，因此 `TryProduceAsync` 和 `ProduceAsync` 都不会等待容量，
+也没有 `BufferQueueFullMode` 配置。接收 `IEnumerable<T>` 的批量便捷重载仍然是扩展方法；对于非数组输入，
+它们会先物化，再调用核心的 `ReadOnlyMemory<T>` 方法。
+
 ## 目录结构
 
 每个 topic partition 存储在：

--- a/docs/design/memory.md
+++ b/docs/design/memory.md
@@ -34,9 +34,11 @@ The partition appends to its tail segment. When the tail is full, it creates a n
 recycles an old segment that every consumer group has fully consumed.
 
 For default round-robin routing, the Memory producer and its partitions share one append lock. The
-lock serializes partition selection, bounded-capacity accounting, and append. Partition-key routing
-selects a partition before taking that partition's append lock, so concurrent producers can append
-to different partitions in parallel. Appends within one partition remain serialized.
+lock serializes partition selection and append; immediate single-item capacity admission also runs
+under this lock. Batch admission and a resumed `Wait` write reserve capacity before taking the
+append lock. Partition-key routing selects a partition before taking that partition's append lock,
+so concurrent producers can append to different partitions in parallel. Appends within one
+partition remain serialized.
 
 After storing the item, the selected partition publishes its new readable cursor with a release
 write. Consumers read the published range without taking an append lock, so they cannot observe a
@@ -63,18 +65,35 @@ has read it.
 
 ## Bounded Capacity
 
-Memory mode supports optional bounded capacity through
-`MemoryBufferQueueOptions.BoundedCapacity`.
+Memory mode supports optional topic-wide bounded capacity through
+`MemoryBufferQueueOptions.BoundedCapacity`. The limit is shared by every partition in the topic.
 
-When capacity is configured and the queue is full:
+`MemoryBufferQueueOptions.FullMode` controls `ProduceAsync` when capacity is
+unavailable. Its default is `BufferQueueFullMode.Wait`:
 
-- `ProduceAsync` throws `BufferQueueFullException`.
-- `TryProduceAsync` returns `false`.
+- `Wait` asynchronously waits for capacity and can be canceled through the
+  method's `CancellationToken`.
+- `Fail` throws `BufferQueueFullException` immediately.
+
+`TryProduceAsync` never waits for bounded capacity. It returns `false`
+immediately when the item or complete batch cannot be admitted.
 
 For a batch, bounded-capacity admission reserves the complete item count before any item is
-appended. If the remaining capacity is insufficient, `ProduceAsync` throws and
-`TryProduceAsync` returns `false`; neither appends a partial batch. This applies to both batch
-input forms after an `IEnumerable<T>` has been materialized.
+appended. If the remaining capacity is insufficient, `TryProduceAsync` returns `false` without
+appending a partial batch. In `Wait` mode, `ProduceAsync` waits for the entire batch to fit and then
+appends it as one admission; callers should pass a cancellation token so that the backpressure wait
+can be stopped. In `Fail` mode, `ProduceAsync` throws. A batch larger than the configured capacity
+is invalid in `Wait` mode and throws `ArgumentOutOfRangeException` rather than waiting forever.
+These rules apply to both batch input forms after an `IEnumerable<T>` has been materialized.
+
+Each partition returns capacity to the topic-wide gate only when the minimum committed position
+across all known consumer groups advances. The release can cover only part of a segment; a group
+that has not committed past the same position continues to hold that capacity. A topic with no
+consumer group cannot release capacity.
+
+A consumer group registered after capacity has already been released starts at the current logical
+earliest position. Records before that position are no longer available to the new group, even if a
+physical segment has not yet been recycled.
 
 MemoryMappedFile currently does not support bounded capacity. See
 [MemoryMappedFile storage](memory-mapped-file.md) for durable-storage behavior.

--- a/docs/design/memory.zh-CN.md
+++ b/docs/design/memory.zh-CN.md
@@ -32,9 +32,10 @@ Memory 数据和 consumer offset 只在当前进程生命周期内存在。进�
 Partition 会向 tail segment 追加数据。Tail 已满时，它会创建新 segment，或者复用一个已被所有 consumer
 group 完全消费的旧 segment。
 
-默认 round-robin 路由时，Memory producer 和 partition 共享一个 append lock，用于串行执行 partition
-选择、有界容量计数和 append。PartitionKey 路由会在获取该 partition 的 append lock 前先选择 partition，
-因此并发 producer 可以并行向不同 partition 写入；同一个 partition 内的 append 仍然串行。
+默认 round-robin 路由时，Memory producer 和 partition 共享一个 append lock，用于串行执行 partition 选择和
+append；单条数据能够立即写入时，也会在这把锁内预留容量。批量写入以及从 `Wait` 恢复的写入会先预留容量，
+再获取 append lock。PartitionKey 路由会先选择 partition，再获取对应的 append lock，因此并发 producer
+可以同时写入不同 partition；同一 partition 内仍然串行 append。
 
 选中的 partition 写入 item 后，使用 release write 发布新的可读 cursor。Consumer 读取已发布区间时不获取
 append lock，因此不会读到尚未写入的 slot。Enqueue 成功后，partition 会通知所有已注册 consumer。
@@ -57,16 +58,30 @@ Memory 模式可以复用旧 segment。只有当所有 consumer group 都已经�
 
 ## 有界容量
 
-Memory 模式支持通过 `MemoryBufferQueueOptions.BoundedCapacity` 配置可选的有界容量。
+Memory 模式可以通过 `MemoryBufferQueueOptions.BoundedCapacity` 限制整个 topic 的容量。该上限由 topic 下的
+所有 partition 共享。
 
-配置容量且 queue 已满时：
+容量不可用时，`MemoryBufferQueueOptions.FullMode` 控制 `ProduceAsync` 的行为，默认值为
+`BufferQueueFullMode.Wait`：
 
-- `ProduceAsync` 抛出 `BufferQueueFullException`。
-- `TryProduceAsync` 返回 `false`。
+- `Wait` 异步等待容量，并可通过方法的 `CancellationToken` 取消等待。
+- `Fail` 立即抛出 `BufferQueueFullException`。
 
-对于批量写入，容量检查会在写入前一次性预留整批数据所需的容量。剩余容量不足时，`ProduceAsync` 抛出异常，
-`TryProduceAsync` 返回 `false`；两者都不会写入部分数据。两种批量输入形式均遵循这一规则，其中非数组的
+`TryProduceAsync` 永远不会等待有界容量。当单条数据或整个批次无法接纳时，它会立即返回
+`false`。
+
+批量写入会在 append 前一次性预留整批数据所需的容量。剩余容量不足时，`TryProduceAsync` 返回 `false`，
+且不会写入部分数据；`ProduceAsync` 在 `Wait` 模式下等待整批所需的容量，调用方应传入取消令牌，以便
+终止背压等待。在 `Fail` 模式下，`ProduceAsync` 会抛出异常。如果批次大小超过配置的总容量，`Wait` 模式
+会抛出 `ArgumentOutOfRangeException`，避免请求永远无法满足。两种批量输入形式都遵循这一规则；非数组的
 `IEnumerable<T>` 会先物化为数组。
+
+每个 partition 只有在所有已知 consumer group 的最小 committed position 向前推进后，才会把对应容量归还给
+topic 共享的容量门。释放范围可以只覆盖 segment 的一部分；尚未提交到同一位置的慢速 group 会继续占用这部分
+容量。Topic 尚未创建 consumer group 时，不会释放容量。
+
+如果新的 consumer group 在容量已经释放后才注册，它会从当前逻辑上的最早位置开始消费。即使旧数据所在的物理
+segment 还没有被复用，新 group 也无法再读取该位置之前的数据。
 
 MemoryMappedFile 当前不支持有界容量。持久化存储行为参见
 [MemoryMappedFile 存储](memory-mapped-file.zh-CN.md)。

--- a/docs/design/partitioning-and-concurrency.md
+++ b/docs/design/partitioning-and-concurrency.md
@@ -70,10 +70,12 @@ The queue is designed for concurrent production and consumption within one proce
 
 - Producers select a partition through round-robin counters by default, or through the configured
   partition-key selector. Selector implementations must be safe for concurrent calls.
-- In Memory mode, default round-robin routing uses one append lock for partition selection,
-  bounded-capacity accounting, and append. Partition-key routing selects a partition first, then
-  uses that partition's append lock, allowing appends to different partitions to proceed in
-  parallel. Appends to one partition remain serialized.
+- In Memory mode, default round-robin routing uses one append lock for partition selection and
+  append. Immediate single-item capacity admission also occurs inside that lock, while batch
+  reservations and writes resumed after a `Wait` reserve their complete capacity before taking the
+  append lock. Partition-key routing selects a partition first, then uses that partition's append
+  lock, allowing appends to different partitions to proceed in parallel. Appends to one partition
+  remain serialized.
 - A Memory partition publishes its readable segment cursor only after it stores the item. Consumers
   never observe an unwritten slot and do not take the append lock while reading.
 - Consumer-group creation is guarded by a queue-level lock.

--- a/docs/design/partitioning-and-concurrency.zh-CN.md
+++ b/docs/design/partitioning-and-concurrency.zh-CN.md
@@ -62,9 +62,10 @@ Queue 的设计目标是在一个进程内并发生产和消费：
 
 - Producer 默认通过 round-robin counter 选择 partition，或通过配置的 PartitionKey selector 选择。
   Selector 实现必须能安全地被并发调用。
-- Memory 模式中，默认 round-robin 路由使用一个 append lock 串行执行 partition 选择、有界容量计数和
-  append。PartitionKey 路由先选择 partition，再获取该 partition 的 append lock，因此不同 partition
-  的 append 可以并行进行；同一 partition 的 append 仍然串行。
+- Memory 模式中，默认 round-robin 路由使用一个 append lock 串行执行 partition 选择和 append。单条数据在
+  容量可用时，也会在这把锁内完成容量接纳；批量预留以及从 `Wait` 恢复的写入，则会先一次性取得所需容量，
+  再获取 append lock。PartitionKey 路由先选择 partition，再获取该 partition 的 append lock，因此不同
+  partition 的 append 可以并行进行；同一 partition 的 append 仍然串行。
 - Memory partition 只会在写入 item 后发布可读 segment cursor，因此 consumer 不会读到未写入 slot，
   读取时也不需要获取 append lock。
 - Consumer group 的创建受 queue-level lock 保护。

--- a/docs/nuget/BufferQueue.MemoryMappedFile/README.md
+++ b/docs/nuget/BufferQueue.MemoryMappedFile/README.md
@@ -93,33 +93,48 @@ using Microsoft.Extensions.DependencyInjection;
 public sealed class OrderEventWriter(
     [FromKeyedServices("order-events")] IBufferProducer<OrderEvent> producer)
 {
-    public ValueTask WriteAsync(OrderEvent orderEvent) =>
-        producer.ProduceAsync(orderEvent);
+    public ValueTask WriteAsync(OrderEvent orderEvent, CancellationToken cancellationToken = default) =>
+        producer.ProduceAsync(orderEvent, cancellationToken);
 }
 ```
 
 For a topic selected at runtime, inject `IBufferQueue` and call
 `GetProducer<T>(topicName)`.
 
-`IBufferProducer<T>` directly exposes `TryProduceAsync` for a single item and
-for `ReadOnlyMemory<T>`. `BufferProducerExtensions` provides the same-name
-`ProduceAsync` forms plus the `IEnumerable<T>` convenience overloads:
+`IBufferProducer<T>` directly exposes four core methods, each with an optional
+`CancellationToken`:
 
 ~~~csharp
+ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+~~~
+
+`BufferProducerExtensions` provides only the `IEnumerable<T>` convenience
+overloads, which also accept a cancellation token:
+
+~~~csharp
+CancellationToken cancellationToken = default;
 ReadOnlyMemory<OrderEvent> bufferedEvents = pendingEvents.AsMemory();
 
-await producer.ProduceAsync(bufferedEvents);
-var accepted = await producer.TryProduceAsync(bufferedEvents);
+await producer.ProduceAsync(bufferedEvents, cancellationToken);
+var accepted = await producer.TryProduceAsync(bufferedEvents, cancellationToken);
 
 IEnumerable<OrderEvent> eventsFromAnEnumerable = GetPendingEvents();
-await producer.ProduceAsync(eventsFromAnEnumerable);
+await producer.ProduceAsync(eventsFromAnEnumerable, cancellationToken);
 ~~~
 
 Use `ReadOnlyMemory<T>` when the source is already contiguous or can be exposed
 as memory. It is the allocation-conscious core form because it avoids the input
 materialization required by a non-array `IEnumerable<T>`. The `IEnumerable<T>` form is
-convenient but materializes a non-array input before batch submission. `ProduceAsync`
-is an extension that converts a rejected try into the normal full-queue exception.
+convenient but materializes a non-array input before batch submission. The single-item and
+`ReadOnlyMemory<T>` `ProduceAsync` methods are core interface methods, not extensions.
+
+MemoryMappedFile topics are unbounded. `TryProduceAsync` and `ProduceAsync` use
+the same cancellation-aware API as Memory storage, but neither waits for capacity
+and there is no `FullMode` option. Each batch item is still routed and persisted as
+an individual record according to the configured flush strategy.
 
 MMF processes every batch item as a normal record: it selects the partition,
 serializes the item, writes its record, and applies the configured flush

--- a/docs/nuget/BufferQueue.MemoryMappedFile/README.zh-CN.md
+++ b/docs/nuget/BufferQueue.MemoryMappedFile/README.zh-CN.md
@@ -84,30 +84,42 @@ using Microsoft.Extensions.DependencyInjection;
 public sealed class OrderEventWriter(
     [FromKeyedServices("order-events")] IBufferProducer<OrderEvent> producer)
 {
-    public ValueTask WriteAsync(OrderEvent orderEvent) =>
-        producer.ProduceAsync(orderEvent);
+    public ValueTask WriteAsync(OrderEvent orderEvent, CancellationToken cancellationToken = default) =>
+        producer.ProduceAsync(orderEvent, cancellationToken);
 }
 ```
 
 需要在运行时选择 topic 时，注入 `IBufferQueue` 并调用 `GetProducer<T>(topicName)`。
 
-`IBufferProducer<T>` 直接提供单条数据和 `ReadOnlyMemory<T>` 两种 `TryProduceAsync` 方法。
-`BufferProducerExtensions` 在此基础上提供对应的 `ProduceAsync` 形式，以及接收 `IEnumerable<T>` 的便捷重载：
+`IBufferProducer<T>` 直接提供四个核心方法，每个方法都接收可选的 `CancellationToken`：
 
 ~~~csharp
+ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+~~~
+
+`BufferProducerExtensions` 只提供接收 `IEnumerable<T>` 的便捷重载，这些重载同样接收 `CancellationToken`：
+
+~~~csharp
+CancellationToken cancellationToken = default;
 ReadOnlyMemory<OrderEvent> bufferedEvents = pendingEvents.AsMemory();
 
-await producer.ProduceAsync(bufferedEvents);
-var accepted = await producer.TryProduceAsync(bufferedEvents);
+await producer.ProduceAsync(bufferedEvents, cancellationToken);
+var accepted = await producer.TryProduceAsync(bufferedEvents, cancellationToken);
 
 IEnumerable<OrderEvent> eventsFromAnEnumerable = GetPendingEvents();
-await producer.ProduceAsync(eventsFromAnEnumerable);
+await producer.ProduceAsync(eventsFromAnEnumerable, cancellationToken);
 ~~~
 
 数据已经连续存储，或可以直接表示为内存区间时，应优先使用 `ReadOnlyMemory<T>`。这是核心批量写入形式，
 能避免非数组 `IEnumerable<T>` 在提交前产生的物化。`IEnumerable<T>` 重载用于方便调用；当输入不是数组时，
-会先物化为数组，再提交整个批次。`ProduceAsync` 是扩展方法：当 `TryProduceAsync` 返回 `false` 时，它会抛出
-队列已满异常。
+会先物化为数组，再提交整个批次。单条和 `ReadOnlyMemory<T>` 的 `ProduceAsync` 都是核心接口方法，不是扩展方法。
+
+MemoryMappedFile topic 没有有界容量。它与 Memory 存储使用相同的、支持取消的 `IBufferProducer<T>` API，
+但 `TryProduceAsync` 和 `ProduceAsync` 都不会等待容量，也没有 `FullMode` 配置。批次中的每条数据仍会根据配置的
+flush 策略单独路由并持久化为一条记录。
 
 MMF 会将批次中的每条数据视为一条普通记录：选择 partition、序列化、写入记录，然后应用配置的 flush
 策略。一个批次不会合并为一条记录，也不会作为单个 partition 的分组或一次 flush 的单位。

--- a/docs/nuget/BufferQueue/README.md
+++ b/docs/nuget/BufferQueue/README.md
@@ -22,6 +22,7 @@ package.
 
 ```csharp
 using BufferQueue;
+using BufferQueue.Memory;
 
 builder.Services.AddBufferQueue(queue =>
 {
@@ -36,6 +37,7 @@ builder.Services.AddBufferQueue(queue =>
 
                 // Optional. Memory topics are unbounded by default.
                 topic.BoundedCapacity = 100_000;
+                topic.FullMode = BufferQueueFullMode.Wait;
             });
         })
         .AddPushCustomers(typeof(Program).Assembly);
@@ -74,39 +76,55 @@ using Microsoft.Extensions.DependencyInjection;
 public sealed class OrderWriter(
     [FromKeyedServices("orders")] IBufferProducer<Order> producer)
 {
-    public ValueTask WriteAsync(Order order) =>
-        producer.ProduceAsync(order);
+    public ValueTask WriteAsync(Order order, CancellationToken cancellationToken = default) =>
+        producer.ProduceAsync(order, cancellationToken);
 }
 ```
 
 For a topic selected at runtime, inject `IBufferQueue` and call
 `GetProducer<T>(topicName)`.
 
-`IBufferProducer<T>` directly exposes `TryProduceAsync` for a single item and
-for `ReadOnlyMemory<T>`. `BufferProducerExtensions` provides the same-name
-`ProduceAsync` forms plus the `IEnumerable<T>` convenience overloads:
+`IBufferProducer<T>` directly exposes four core methods, each with an optional
+`CancellationToken`:
 
 ~~~csharp
+ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+~~~
+
+`BufferProducerExtensions` provides only the `IEnumerable<T>` convenience
+overloads, which also accept a cancellation token:
+
+~~~csharp
+CancellationToken cancellationToken = default;
 ReadOnlyMemory<Order> bufferedOrders = pendingOrders.AsMemory();
 
-await producer.ProduceAsync(bufferedOrders);
-var accepted = await producer.TryProduceAsync(bufferedOrders);
+await producer.ProduceAsync(bufferedOrders, cancellationToken);
+var accepted = await producer.TryProduceAsync(bufferedOrders, cancellationToken);
 
 IEnumerable<Order> ordersFromAnEnumerable = GetPendingOrders();
-await producer.ProduceAsync(ordersFromAnEnumerable);
+await producer.ProduceAsync(ordersFromAnEnumerable, cancellationToken);
 ~~~
 
 Use `ReadOnlyMemory<T>` when the source is already contiguous or can be exposed
 as memory. It is the allocation-conscious core form because it avoids the input
 materialization required by a non-array `IEnumerable<T>`. The `IEnumerable<T>` form is
-convenient but materializes a non-array input before batch submission. `ProduceAsync`
-is an extension that converts a rejected try into the normal full-queue exception.
+convenient but materializes a non-array input before batch submission. The single-item and
+`ReadOnlyMemory<T>` `ProduceAsync` methods are core interface methods, not extensions.
 
-On a bounded Memory topic, `ProduceAsync` throws
-`BufferQueueFullException` when the queue is full. Use `TryProduceAsync`
-when a `false` result is preferable to an exception. A batch must fit as a
-whole: if the remaining capacity is insufficient, `ProduceAsync` throws and
-`TryProduceAsync` returns `false` without appending any item from that batch.
+On a bounded Memory topic, `FullMode` defaults to `Wait`: `ProduceAsync` asynchronously
+waits until capacity is available. Supply a cancellation token so that the backpressure
+wait can be canceled. Set `FullMode` to `Fail` when immediate rejection is required;
+`ProduceAsync` then throws `BufferQueueFullException`. `TryProduceAsync` never waits and
+returns `false` immediately when the item or complete batch cannot be admitted. Batch admission
+is all-or-nothing. In `Wait` mode, the producer waits for the entire batch and a batch larger than
+the configured capacity is invalid. The capacity limit is shared by every partition. Each partition returns
+capacity as the minimum committed position across all known consumer groups advances, including
+within a segment, so a slow group can hold capacity after another group commits. A group created
+later starts at the current logical earliest position and cannot read records whose capacity has
+already been released.
 
 ## Consume in batches
 

--- a/docs/nuget/BufferQueue/README.zh-CN.md
+++ b/docs/nuget/BufferQueue/README.zh-CN.md
@@ -20,6 +20,7 @@ dotnet add package BufferQueue
 
 ```csharp
 using BufferQueue;
+using BufferQueue.Memory;
 
 builder.Services.AddBufferQueue(queue =>
 {
@@ -32,8 +33,9 @@ builder.Services.AddBufferQueue(queue =>
                 topic.PartitionNumber = 4;
                 topic.UsePartitionKey(order => order.Id);
 
-                // Optional. Memory topics are unbounded by default.
+                // 可选。Memory topic 默认不限制容量。
                 topic.BoundedCapacity = 100_000;
+                topic.FullMode = BufferQueueFullMode.Wait;
             });
         })
         .AddPushCustomers(typeof(Program).Assembly);
@@ -67,34 +69,46 @@ using Microsoft.Extensions.DependencyInjection;
 public sealed class OrderWriter(
     [FromKeyedServices("orders")] IBufferProducer<Order> producer)
 {
-    public ValueTask WriteAsync(Order order) =>
-        producer.ProduceAsync(order);
+    public ValueTask WriteAsync(Order order, CancellationToken cancellationToken = default) =>
+        producer.ProduceAsync(order, cancellationToken);
 }
 ```
 
 需要在运行时选择 topic 时，注入 `IBufferQueue` 并调用 `GetProducer<T>(topicName)`。
 
-`IBufferProducer<T>` 直接提供单条数据和 `ReadOnlyMemory<T>` 两种 `TryProduceAsync` 方法。
-`BufferProducerExtensions` 在此基础上提供对应的 `ProduceAsync` 形式，以及接收 `IEnumerable<T>` 的便捷重载：
+`IBufferProducer<T>` 直接提供四个核心方法，每个方法都接收可选的 `CancellationToken`：
 
 ~~~csharp
+ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default);
+ValueTask ProduceAsync(ReadOnlyMemory<T> items, CancellationToken cancellationToken = default);
+~~~
+
+`BufferProducerExtensions` 只提供接收 `IEnumerable<T>` 的便捷重载，这些重载同样接收 `CancellationToken`：
+
+~~~csharp
+CancellationToken cancellationToken = default;
 ReadOnlyMemory<Order> bufferedOrders = pendingOrders.AsMemory();
 
-await producer.ProduceAsync(bufferedOrders);
-var accepted = await producer.TryProduceAsync(bufferedOrders);
+await producer.ProduceAsync(bufferedOrders, cancellationToken);
+var accepted = await producer.TryProduceAsync(bufferedOrders, cancellationToken);
 
 IEnumerable<Order> ordersFromAnEnumerable = GetPendingOrders();
-await producer.ProduceAsync(ordersFromAnEnumerable);
+await producer.ProduceAsync(ordersFromAnEnumerable, cancellationToken);
 ~~~
 
 数据已经连续存储，或可以直接表示为内存区间时，应优先使用 `ReadOnlyMemory<T>`。这是核心批量写入形式，
 能避免非数组 `IEnumerable<T>` 在提交前产生的物化。`IEnumerable<T>` 重载用于方便调用；当输入不是数组时，
-会先物化为数组，再提交整个批次。`ProduceAsync` 是扩展方法：当 `TryProduceAsync` 返回 `false` 时，它会抛出
-队列已满异常。
+会先物化为数组，再提交整个批次。单条和 `ReadOnlyMemory<T>` 的 `ProduceAsync` 都是核心接口方法，不是扩展方法。
 
-对于配置了有界容量的 Memory topic，队列已满时 `ProduceAsync` 会抛出 `BufferQueueFullException`。如果更适合
-由调用方处理失败，可使用 `TryProduceAsync` 并检查其 `false` 返回值。批量写入必须整批接纳：剩余容量不足时，
-`ProduceAsync` 抛出异常，`TryProduceAsync` 返回 `false`，且不会写入该批次中的任何一条数据。
+对于配置了有界容量的 Memory topic，`FullMode` 默认为 `Wait`：容量不足时，`ProduceAsync` 会异步等待，直到
+容量可用。生产代码应传入 `CancellationToken`，以便取消背压等待。需要立即拒绝写入时，可将 `FullMode` 设为
+`Fail`；此时 `ProduceAsync` 会抛出 `BufferQueueFullException`。`TryProduceAsync` 永远不会等待，单条数据或整个
+批次无法接纳时会立即返回 `false`。批量接纳必须整批完成；在 `Wait` 模式下，Producer 会等待整个批次，且大于
+配置容量的批次属于无效参数。容量上限由 topic 下的所有 partition 共享。每个 partition 会在所有已知 consumer group 的最小 committed position 向前推进时
+归还容量；即使只推进到 segment 中间，也会归还相应部分，因此较慢的 group 仍可能在其他 group 提交后继续占用
+容量。较晚创建的 consumer group 会从当前逻辑上的最早位置开始消费，无法读取容量已经释放的数据。
 
 ## 批量消费
 

--- a/samples/WebAPI/Controllers/TestController.cs
+++ b/samples/WebAPI/Controllers/TestController.cs
@@ -14,14 +14,14 @@ public class TestController(
     [HttpPost("foo1")]
     public async Task<IActionResult> PostFoo1([FromBody] Foo foo)
     {
-        await foo1Producer.ProduceAsync(foo);
+        await foo1Producer.ProduceAsync(foo, HttpContext.RequestAborted);
         return Ok();
     }
 
     [HttpPost("foo2")]
     public async Task<IActionResult> PostFoo2([FromBody] Foo foo)
     {
-        await foo2Producer.ProduceAsync(foo);
+        await foo2Producer.ProduceAsync(foo, HttpContext.RequestAborted);
         return Ok();
     }
 
@@ -29,9 +29,9 @@ public class TestController(
     public async Task<IActionResult> PostBar([FromBody] Bar bar)
     {
         var producer = bufferQueue.GetProducer<Bar>("topic-bar");
-        await producer.ProduceAsync(bar);
+        await producer.ProduceAsync(bar, HttpContext.RequestAborted);
         // TryProduceAsync can be used if you want to check if the item was produced successfully
-        // bool success = await producer.TryProduceAsync(bar);
+        // bool success = await producer.TryProduceAsync(bar, HttpContext.RequestAborted);
         return Ok();
     }
 }

--- a/samples/WebAPI/Program.cs
+++ b/samples/WebAPI/Program.cs
@@ -1,4 +1,5 @@
 using BufferQueue;
+using BufferQueue.Memory;
 using WebAPI;
 using WebApp;
 
@@ -35,7 +36,8 @@ builder.Services.AddBufferQueue(bufferOptionsBuilder =>
                 {
                     options.TopicName = "topic-bar";
                     options.PartitionNumber = 8;
-                    options.BoundedCapacity = 100_000; // Set a bounded capacity for the Bar topic
+                    options.BoundedCapacity = 100_000;
+                    options.FullMode = BufferQueueFullMode.Wait;
                 });
         })
         .AddPushCustomers(typeof(Program).Assembly);

--- a/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferOptionsBuilder.cs
+++ b/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferOptionsBuilder.cs
@@ -14,36 +14,8 @@ public class MemoryMappedFileBufferOptionsBuilder(IServiceCollection services)
         var options = new MemoryMappedFileBufferQueueOptions<T>();
         configure(options);
 
-        var topicName = options.TopicName;
-        var partitionNumber = options.PartitionNumber;
-
-        if (string.IsNullOrWhiteSpace(topicName))
-        {
-            throw new ArgumentException("Topic name cannot be null or whitespace.", nameof(options.TopicName));
-        }
-
-        if (partitionNumber <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.PartitionNumber),
-                "Partition number must be greater than zero.");
-        }
-
-        _ = options.GetSegmentSizeInBytes();
-        _ = options.GetMaxRetainedConsumedSegments();
-
-        if (!Enum.IsDefined(options.FlushStrategy))
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.FlushStrategy),
-                "The flush strategy is not supported.");
-        }
-
-        if (options.FlushStrategy == MemoryMappedFileFlushStrategy.Batch && options.FlushBatchSize <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.FlushBatchSize),
-                "Flush batch size must be greater than zero when using the batch flush strategy.");
-        }
-
-        ArgumentNullException.ThrowIfNull(options.Serializer, nameof(options.Serializer));
+        options.Validate();
+        var topicName = options.TopicName!;
 
         if (options.PartitionIndexSelector is { } partitionIndexSelector)
         {

--- a/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferProducer.cs
+++ b/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferProducer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BufferQueue.MemoryMappedFile;
@@ -12,20 +13,46 @@ internal sealed class MemoryMappedFileBufferProducer<T>(
 {
     public string TopicName { get; } = options.TopicName!;
 
-    public ValueTask<bool> TryProduceAsync(T item)
+    public ValueTask<bool> TryProduceAsync(
+        T item,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         Enqueue(item);
         return new(true);
     }
 
-    public ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items)
+    public ValueTask<bool> TryProduceAsync(
+        ReadOnlyMemory<T> items,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         foreach (var item in items.Span)
         {
             Enqueue(item);
         }
 
         return new(true);
+    }
+
+    public ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        Enqueue(item);
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask ProduceAsync(
+        ReadOnlyMemory<T> items,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        foreach (var item in items.Span)
+        {
+            Enqueue(item);
+        }
+
+        return ValueTask.CompletedTask;
     }
 
     private void Enqueue(T item)

--- a/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferQueue.cs
+++ b/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferQueue.cs
@@ -21,7 +21,7 @@ internal sealed class MemoryMappedFileBufferQueue<T> : BufferQueue<T>, IDisposab
     internal MemoryMappedFileBufferQueue(
         MemoryMappedFileBufferQueueOptions<T> options,
         IPartitioner<T> partitioner)
-        : this(options, partitioner, CreatePartitions(options))
+        : this(options.Validate(), partitioner, CreatePartitions(options))
     {
     }
 
@@ -51,7 +51,6 @@ internal sealed class MemoryMappedFileBufferQueue<T> : BufferQueue<T>, IDisposab
 
     private static MemoryMappedFileBufferPartition<T>[] CreatePartitions(MemoryMappedFileBufferQueueOptions<T> options)
     {
-        ValidateOptions(options);
         ValidateExistingPartitions(options);
 
         var partitions = new MemoryMappedFileBufferPartition<T>[options.PartitionNumber];
@@ -75,25 +74,6 @@ internal sealed class MemoryMappedFileBufferQueue<T> : BufferQueue<T>, IDisposab
         }
 
         return partitions;
-    }
-
-    private static void ValidateOptions(MemoryMappedFileBufferQueueOptions<T> options)
-    {
-        _ = options.GetSegmentSizeInBytes();
-        _ = options.GetMaxRetainedConsumedSegments();
-        ArgumentNullException.ThrowIfNull(options.Serializer, nameof(options.Serializer));
-
-        if (!Enum.IsDefined(options.FlushStrategy))
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.FlushStrategy),
-                "The flush strategy is not supported.");
-        }
-
-        if (options.FlushStrategy == MemoryMappedFileFlushStrategy.Batch && options.FlushBatchSize <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.FlushBatchSize),
-                "Flush batch size must be greater than zero when using the batch flush strategy.");
-        }
     }
 
     private static void ValidateExistingPartitions(MemoryMappedFileBufferQueueOptions<T> options)

--- a/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferQueueOptions.cs
+++ b/src/BufferQueue.MemoryMappedFile/MemoryMappedFileBufferQueueOptions.cs
@@ -83,6 +83,38 @@ public class MemoryMappedFileBufferQueueOptions<T>
             PartitionKeyRouting.SelectStringPartition(partitionKeySelector(item), partitionCount);
     }
 
+    internal MemoryMappedFileBufferQueueOptions<T> Validate()
+    {
+        if (string.IsNullOrWhiteSpace(TopicName))
+        {
+            throw new ArgumentException("Topic name cannot be null or whitespace.", nameof(TopicName));
+        }
+
+        if (PartitionNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(PartitionNumber),
+                "Partition number must be greater than zero.");
+        }
+
+        _ = GetSegmentSizeInBytes();
+        _ = GetMaxRetainedConsumedSegments();
+
+        if (!Enum.IsDefined(FlushStrategy))
+        {
+            throw new ArgumentOutOfRangeException(nameof(FlushStrategy),
+                "The flush strategy is not supported.");
+        }
+
+        if (FlushStrategy == MemoryMappedFileFlushStrategy.Batch && FlushBatchSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(FlushBatchSize),
+                "Flush batch size must be greater than zero when using the batch flush strategy.");
+        }
+
+        ArgumentNullException.ThrowIfNull(Serializer, nameof(Serializer));
+        return this;
+    }
+
     internal long GetSegmentSizeInBytes()
     {
         if (SegmentSizeInBytes <= MemoryMappedFileBufferPartition<T>.MaxRecordOverhead)

--- a/src/BufferQueue/BufferProducerExtensions.cs
+++ b/src/BufferQueue/BufferProducerExtensions.cs
@@ -1,65 +1,37 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BufferQueue;
 
 public static class BufferProducerExtensions
 {
-    public static ValueTask ProduceAsync<T>(this IBufferProducer<T> producer, T item)
+    public static ValueTask ProduceAsync<T>(
+        this IBufferProducer<T> producer,
+        IEnumerable<T> items,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(producer);
-        return ProduceAsync(producer.TryProduceAsync(item), producer.TopicName, "item");
+        ArgumentNullException.ThrowIfNull(items);
+        cancellationToken.ThrowIfCancellationRequested();
+        return producer.ProduceAsync(GetItems(items), cancellationToken);
     }
 
-    public static ValueTask ProduceAsync<T>(this IBufferProducer<T> producer, ReadOnlyMemory<T> items)
+    public static ValueTask<bool> TryProduceAsync<T>(
+        this IBufferProducer<T> producer,
+        IEnumerable<T> items,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(producer);
-        return ProduceAsync(producer.TryProduceAsync(items), producer.TopicName, "batch");
-    }
-
-    public static ValueTask ProduceAsync<T>(this IBufferProducer<T> producer, IEnumerable<T> items)
-    {
-        ArgumentNullException.ThrowIfNull(producer);
-        return ProduceAsync(producer, GetItems(items));
-    }
-
-    public static ValueTask<bool> TryProduceAsync<T>(this IBufferProducer<T> producer, IEnumerable<T> items)
-    {
-        ArgumentNullException.ThrowIfNull(producer);
-        return producer.TryProduceAsync(GetItems(items));
+        ArgumentNullException.ThrowIfNull(items);
+        cancellationToken.ThrowIfCancellationRequested();
+        return producer.TryProduceAsync(GetItems(items), cancellationToken);
     }
 
     private static ReadOnlyMemory<T> GetItems<T>(IEnumerable<T> items)
     {
-        ArgumentNullException.ThrowIfNull(items);
         return items is T[] array ? array : items.ToArray();
     }
-
-    private static ValueTask ProduceAsync(ValueTask<bool> result, string topicName, string subject)
-    {
-        if (result.IsCompletedSuccessfully)
-        {
-            if (result.Result)
-            {
-                return ValueTask.CompletedTask;
-            }
-
-            throw CreateQueueFullException(topicName, subject);
-        }
-
-        return AwaitProduceAsync(result, topicName, subject);
-    }
-
-    private static async ValueTask AwaitProduceAsync(ValueTask<bool> result, string topicName, string subject)
-    {
-        if (!await result.ConfigureAwait(false))
-        {
-            throw CreateQueueFullException(topicName, subject);
-        }
-    }
-
-    private static BufferQueueFullException CreateQueueFullException(string topicName, string subject) =>
-        new($"The queue '{topicName}' is full, and the {subject} cannot be produced.");
 }

--- a/src/BufferQueue/IBufferProducer.cs
+++ b/src/BufferQueue/IBufferProducer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BufferQueue;
@@ -7,7 +8,15 @@ public interface IBufferProducer<T>
 {
     string TopicName { get; }
 
-    ValueTask<bool> TryProduceAsync(T item);
+    ValueTask<bool> TryProduceAsync(T item, CancellationToken cancellationToken = default);
 
-    ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items);
+    ValueTask<bool> TryProduceAsync(
+        ReadOnlyMemory<T> items,
+        CancellationToken cancellationToken = default);
+
+    ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default);
+
+    ValueTask ProduceAsync(
+        ReadOnlyMemory<T> items,
+        CancellationToken cancellationToken = default);
 }

--- a/src/BufferQueue/Memory/BufferQueueFullMode.cs
+++ b/src/BufferQueue/Memory/BufferQueueFullMode.cs
@@ -1,0 +1,14 @@
+namespace BufferQueue.Memory;
+
+public enum BufferQueueFullMode
+{
+    /// <summary>
+    /// Asynchronously waits until capacity becomes available.
+    /// </summary>
+    Wait,
+
+    /// <summary>
+    /// Fails the write immediately.
+    /// </summary>
+    Fail
+}

--- a/src/BufferQueue/Memory/MemoryBufferCapacityGate.cs
+++ b/src/BufferQueue/Memory/MemoryBufferCapacityGate.cs
@@ -1,11 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace BufferQueue.Memory;
 
 internal sealed class MemoryBufferCapacityGate
 {
+    private readonly object _syncRoot = new();
     private readonly ulong _capacity;
+    private readonly LinkedList<Waiter> _waiters = [];
+    private int _hasWaiters;
     private ulong _availableSlots;
 
     public MemoryBufferCapacityGate(ulong capacity)
@@ -13,6 +18,8 @@ internal sealed class MemoryBufferCapacityGate
         _capacity = capacity;
         _availableSlots = capacity;
     }
+
+    public ulong Capacity => _capacity;
 
     public bool TryAcquire()
     {
@@ -26,6 +33,141 @@ internal sealed class MemoryBufferCapacityGate
             return true;
         }
 
+        if (Volatile.Read(ref _hasWaiters) != 0)
+        {
+            return false;
+        }
+
+        return TryAcquireCore(count);
+    }
+
+    public ValueTask AcquireAsync(ulong count, CancellationToken cancellationToken)
+    {
+        if (count > _capacity)
+        {
+            throw new ArgumentOutOfRangeException(nameof(count),
+                "The requested capacity cannot exceed the queue capacity.");
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return ValueTask.FromCanceled(cancellationToken);
+        }
+
+        if (count == 0)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        if (TryAcquire(count))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        Waiter waiter;
+        CancellationTokenRegistration cancellationRegistration = default;
+        var unregisterCancellation = false;
+
+        lock (_syncRoot)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return ValueTask.FromCanceled(cancellationToken);
+            }
+
+            Volatile.Write(ref _hasWaiters, 1);
+            if (_waiters.Count == 0 && TryAcquireCore(count))
+            {
+                Volatile.Write(ref _hasWaiters, 0);
+                return ValueTask.CompletedTask;
+            }
+
+            waiter = new(this, count, cancellationToken);
+            waiter.Node = _waiters.AddLast(waiter);
+
+            if (cancellationToken.CanBeCanceled)
+            {
+                cancellationRegistration = cancellationToken.UnsafeRegister(
+                    static state => ((Waiter)state!).Cancel(),
+                    waiter);
+                waiter.CancellationRegistration = cancellationRegistration;
+                unregisterCancellation = waiter.IsCompleted;
+            }
+        }
+
+        if (unregisterCancellation)
+        {
+            cancellationRegistration.Unregister();
+        }
+
+        return new(waiter.Completion.Task);
+    }
+
+    public void Release(ulong count = 1)
+    {
+        if (count == 0)
+        {
+            return;
+        }
+
+        ReleaseCore(count);
+        if (Volatile.Read(ref _hasWaiters) == 0)
+        {
+            return;
+        }
+
+        List<Waiter>? readyWaiters;
+        lock (_syncRoot)
+        {
+            readyWaiters = DrainReadyWaiters();
+        }
+
+        CompleteReadyWaiters(readyWaiters);
+    }
+
+    private void Cancel(Waiter waiter)
+    {
+        List<Waiter>? readyWaiters;
+        lock (_syncRoot)
+        {
+            if (waiter.IsCompleted)
+            {
+                return;
+            }
+
+            _waiters.Remove(waiter.Node!);
+            waiter.Node = null;
+            waiter.IsCompleted = true;
+            readyWaiters = DrainReadyWaiters();
+        }
+
+        waiter.CancellationRegistration.Unregister();
+        waiter.Completion.TrySetCanceled(waiter.CancellationToken);
+        CompleteReadyWaiters(readyWaiters);
+    }
+
+    private List<Waiter>? DrainReadyWaiters()
+    {
+        List<Waiter>? readyWaiters = null;
+        while (_waiters.First is { } node && TryAcquireCore(node.Value.Count))
+        {
+            var waiter = node.Value;
+            _waiters.RemoveFirst();
+            waiter.Node = null;
+            waiter.IsCompleted = true;
+            (readyWaiters ??= []).Add(waiter);
+        }
+
+        if (_waiters.Count == 0)
+        {
+            Volatile.Write(ref _hasWaiters, 0);
+        }
+
+        return readyWaiters;
+    }
+
+    private bool TryAcquireCore(ulong count)
+    {
         var spinWait = new SpinWait();
         while (true)
         {
@@ -48,13 +190,8 @@ internal sealed class MemoryBufferCapacityGate
         }
     }
 
-    public void Release(ulong count = 1)
+    private void ReleaseCore(ulong count)
     {
-        if (count == 0)
-        {
-            return;
-        }
-
         var spinWait = new SpinWait();
         while (true)
         {
@@ -75,5 +212,39 @@ internal sealed class MemoryBufferCapacityGate
 
             spinWait.SpinOnce();
         }
+    }
+
+    private static void CompleteReadyWaiters(List<Waiter>? readyWaiters)
+    {
+        if (readyWaiters == null)
+        {
+            return;
+        }
+
+        foreach (var waiter in readyWaiters)
+        {
+            waiter.CancellationRegistration.Dispose();
+            waiter.Completion.TrySetResult();
+        }
+    }
+
+    private sealed class Waiter(
+        MemoryBufferCapacityGate owner,
+        ulong count,
+        CancellationToken cancellationToken)
+    {
+        public ulong Count { get; } = count;
+
+        public CancellationToken CancellationToken { get; } = cancellationToken;
+
+        public TaskCompletionSource Completion { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public LinkedListNode<Waiter>? Node { get; set; }
+
+        public CancellationTokenRegistration CancellationRegistration { get; set; }
+
+        public bool IsCompleted { get; set; }
+
+        public void Cancel() => owner.Cancel(this);
     }
 }

--- a/src/BufferQueue/Memory/MemoryBufferOptionsBuilder.cs
+++ b/src/BufferQueue/Memory/MemoryBufferOptionsBuilder.cs
@@ -11,7 +11,7 @@ public class MemoryBufferOptionsBuilder(IServiceCollection services)
     {
         ArgumentNullException.ThrowIfNull(configure);
 
-        return AddTopic<T>((MemoryBufferQueueOptions<T> options) => configure(options));
+        return AddTopic((MemoryBufferQueueOptions<T> options) => configure(options));
     }
 
     public MemoryBufferOptionsBuilder AddTopic<T>(
@@ -23,19 +23,8 @@ public class MemoryBufferOptionsBuilder(IServiceCollection services)
         var options = new MemoryBufferQueueOptions<T>();
         configure(options);
 
-        var topicName = options.TopicName;
-        var partitionNumber = options.PartitionNumber;
-
-        if (string.IsNullOrWhiteSpace(topicName))
-        {
-            throw new ArgumentException("Topic name cannot be null or whitespace.", nameof(options.TopicName));
-        }
-
-        if (partitionNumber <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(options.PartitionNumber),
-                "Partition number must be greater than zero.");
-        }
+        options.Validate();
+        var topicName = options.TopicName!;
 
         if (options.PartitionIndexSelector is { } partitionIndexSelector)
         {

--- a/src/BufferQueue/Memory/MemoryBufferPartition.cs
+++ b/src/BufferQueue/Memory/MemoryBufferPartition.cs
@@ -23,6 +23,8 @@ internal sealed class MemoryBufferPartition<T>
     private readonly HashSet<IBufferPartitionConsumer<T>> _consumers;
 
     private readonly object _appendLock;
+    private MemoryBufferPartitionOffset _releasedCapacityPosition;
+    private Action<ulong>? _releaseCapacity;
 
     public MemoryBufferPartition(int id, int segmentSize)
         : this(id, segmentSize, new())
@@ -40,6 +42,7 @@ internal sealed class MemoryBufferPartition<T>
         _consumers = [];
 
         _appendLock = appendLock;
+        _releasedCapacityPosition = _head.StartOffset;
     }
 
     public int PartitionId { get; }
@@ -57,21 +60,54 @@ internal sealed class MemoryBufferPartition<T>
         }
     }
 
-    public void RegisterConsumer(IBufferPartitionConsumer<T> consumer) => _consumers.Add(consumer);
+    public void RegisterConsumer(IBufferPartitionConsumer<T> consumer)
+    {
+        lock (_appendLock)
+        {
+            _consumers.Add(consumer);
+            _consumerReaders.TryAdd(consumer.GroupName, CreateReader());
+        }
+    }
 
-    public void UnregisterConsumer(IBufferPartitionConsumer<T> consumer) => _consumers.Remove(consumer);
+    public void UnregisterConsumer(IBufferPartitionConsumer<T> consumer)
+    {
+        ulong releasedCount;
+        lock (_appendLock)
+        {
+            _consumers.Remove(consumer);
+            _consumerReaders.TryRemove(consumer.GroupName, out _);
+            releasedCount = ReleaseCommittedCapacity();
+        }
+
+        _releaseCapacity?.Invoke(releasedCount);
+    }
 
     public void Enqueue(T item)
     {
         lock (_appendLock)
         {
-            _ = AppendSingleWriter(item);
+            AppendSingleWriter(item);
         }
 
         NotifyConsumers();
     }
 
-    internal ulong AppendFromSerializedProducer(T item) => AppendSingleWriter(item);
+    internal void AppendFromSerializedProducer(T item) => AppendSingleWriter(item);
+
+    internal void SetCapacityReleaseHandler(Action<ulong> releaseCapacity)
+    {
+        ArgumentNullException.ThrowIfNull(releaseCapacity);
+
+        lock (_appendLock)
+        {
+            if (_releaseCapacity != null)
+            {
+                throw new InvalidOperationException("A capacity release handler is already registered.");
+            }
+
+            _releaseCapacity = releaseCapacity;
+        }
+    }
 
     internal void NotifyConsumers()
     {
@@ -81,20 +117,19 @@ internal sealed class MemoryBufferPartition<T>
         }
     }
 
-    private ulong AppendSingleWriter(T item)
+    private void AppendSingleWriter(T item)
     {
         var tail = _tail;
         if (tail.TryEnqueueSingleWriter(item))
         {
-            return 0;
+            return;
         }
 
         var newSegmentStartOffset = tail.EndOffset + 1;
         var newSegment = TryRecycleSegment(
             newSegmentStartOffset,
             out var recycledSegment,
-            out var recycledHead,
-            out var reclaimedCount)
+            out var recycledHead)
             ? recycledSegment
             : new(_segmentSize, newSegmentStartOffset);
         if (!newSegment.TryEnqueueSingleWriter(item))
@@ -108,38 +143,45 @@ internal sealed class MemoryBufferPartition<T>
         {
             _head = recycledHead;
         }
-
-        return reclaimedCount;
     }
 
     public bool TryPull(string groupName, int batchSize, [NotNullWhen(true)] out IEnumerable<T>? items)
     {
-        var reader = _consumerReaders.GetOrAdd(
-            groupName,
-            _ => new Reader(_head, _head.StartOffset));
+        if (!_consumerReaders.TryGetValue(groupName, out var reader))
+        {
+            lock (_appendLock)
+            {
+                reader = _consumerReaders.GetOrAdd(groupName, _ => CreateReader());
+            }
+        }
 
         return reader.TryRead(batchSize, out items);
     }
 
     public void Commit(string groupName)
     {
-        if (!_consumerReaders.TryGetValue(groupName, out var reader))
+        ulong releasedCount;
+        lock (_appendLock)
         {
-            throw new InvalidOperationException("Specified group name not found.");
+            if (!_consumerReaders.TryGetValue(groupName, out var reader))
+            {
+                throw new InvalidOperationException("Specified group name not found.");
+            }
+
+            reader.MoveNext();
+            releasedCount = ReleaseCommittedCapacity();
         }
 
-        reader.MoveNext();
+        _releaseCapacity?.Invoke(releasedCount);
     }
 
     private bool TryRecycleSegment(
         MemoryBufferPartitionOffset newSegmentStartOffset,
         [NotNullWhen(true)] out MemoryBufferSegment<T>? recycledSegment,
-        out MemoryBufferSegment<T>? recycledHead,
-        out ulong reclaimedCount)
+        out MemoryBufferSegment<T>? recycledHead)
     {
         recycledSegment = null;
         recycledHead = null;
-        reclaimedCount = 0;
 
         if (_head == _tail)
         {
@@ -155,13 +197,11 @@ internal sealed class MemoryBufferPartition<T>
             if (wholeSegmentConsumed)
             {
                 recyclableSegment = segment;
-                reclaimedCount += (ulong)segment.Count;
             }
         }
 
         if (recyclableSegment == null)
         {
-            reclaimedCount = 0;
             return false;
         }
 
@@ -169,6 +209,33 @@ internal sealed class MemoryBufferPartition<T>
         recycledHead = recyclableSegment.NextSegment!;
 
         return true;
+    }
+
+    private Reader CreateReader()
+    {
+        var head = _head;
+        var startPosition = _releasedCapacityPosition > head.StartOffset
+            ? _releasedCapacityPosition
+            : head.StartOffset;
+        return new(head, startPosition);
+    }
+
+    private ulong ReleaseCommittedCapacity()
+    {
+        if (_releaseCapacity == null || _consumerReaders.IsEmpty)
+        {
+            return 0;
+        }
+
+        var minConsumerReadPosition = MinConsumerReadPosition();
+        if (!(minConsumerReadPosition > _releasedCapacityPosition))
+        {
+            return 0;
+        }
+
+        var releasedCount = (minConsumerReadPosition - _releasedCapacityPosition).ToUInt64();
+        _releasedCapacityPosition = minConsumerReadPosition;
+        return releasedCount;
     }
 
     private MemoryBufferPartitionOffset MinConsumerReadPosition()
@@ -213,13 +280,8 @@ internal sealed class MemoryBufferPartition<T>
 
             while (true)
             {
-                if (currentSegment.EndOffset < readPosition)
+                while (currentSegment.EndOffset < readPosition && currentSegment.NextSegment != null)
                 {
-                    if (currentSegment.NextSegment == null)
-                    {
-                        break;
-                    }
-
                     currentSegment = currentSegment.NextSegment;
                 }
 

--- a/src/BufferQueue/Memory/MemoryBufferProducer.cs
+++ b/src/BufferQueue/Memory/MemoryBufferProducer.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace BufferQueue.Memory;
@@ -22,25 +24,109 @@ internal sealed class MemoryBufferProducer<T>(
     {
     }
 
-    private readonly MemoryBufferCapacityGate? _capacityGate = options.BoundedCapacity is { } capacity
-        ? new(capacity)
-        : null;
+    private readonly MemoryBufferCapacityGate? _capacityGate = CreateCapacityGate(options, partitions);
+    private readonly BufferQueueFullMode _fullMode = options.FullMode;
     private readonly object? _serializedAppendLock = partitioner.SupportsConcurrentSelection
         ? null
         : GetSharedAppendLock(partitions);
 
     public string TopicName { get; } = options.TopicName!;
 
-    public ValueTask<bool> TryProduceAsync(T item)
+    public ValueTask<bool> TryProduceAsync(
+        T item,
+        CancellationToken cancellationToken = default)
     {
-        var succeeded = TryEnqueue(item);
-        return new(succeeded);
+        cancellationToken.ThrowIfCancellationRequested();
+        return new(TryEnqueue(item));
     }
 
-    public ValueTask<bool> TryProduceAsync(ReadOnlyMemory<T> items)
+    public ValueTask<bool> TryProduceAsync(
+        ReadOnlyMemory<T> items,
+        CancellationToken cancellationToken = default)
     {
-        var succeeded = TryEnqueueBatch(items.Span);
-        return new(succeeded);
+        cancellationToken.ThrowIfCancellationRequested();
+        return new(TryEnqueueBatch(items.Span));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ValueTask ProduceAsync(T item, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (TryEnqueue(item))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return HandleFullItem(item, cancellationToken);
+    }
+
+    private ValueTask HandleFullItem(T item, CancellationToken cancellationToken)
+    {
+        if (_fullMode == BufferQueueFullMode.Fail)
+        {
+            throw CreateQueueFullException("item");
+        }
+
+        return EnqueueWhenCapacityAvailableAsync(item, cancellationToken);
+    }
+
+    public ValueTask ProduceAsync(
+        ReadOnlyMemory<T> items,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (items.IsEmpty)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        if (items.Length == 1)
+        {
+            return ProduceAsync(items.Span[0], cancellationToken);
+        }
+
+        var capacityGate = _capacityGate;
+        if (capacityGate != null && (ulong)items.Length > capacityGate.Capacity)
+        {
+            if (_fullMode == BufferQueueFullMode.Fail)
+            {
+                throw CreateQueueFullException("batch");
+            }
+
+            throw new ArgumentOutOfRangeException(nameof(items),
+                "The batch size cannot exceed the bounded queue capacity.");
+        }
+
+        if (_serializedAppendLock != null)
+        {
+            if (TryEnqueueBatchSerialized(items.Span))
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            return HandleFullBatch(items, null, cancellationToken);
+        }
+
+        var itemsByPartition = GroupItemsByPartition(items.Span);
+        if (TryEnqueueBatchConcurrent(itemsByPartition, items.Length))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return HandleFullBatch(items, itemsByPartition, cancellationToken);
+    }
+
+    private ValueTask HandleFullBatch(
+        ReadOnlyMemory<T> items,
+        List<T>?[]? itemsByPartition,
+        CancellationToken cancellationToken)
+    {
+        if (_fullMode == BufferQueueFullMode.Fail)
+        {
+            throw CreateQueueFullException("batch");
+        }
+
+        return EnqueueBatchWhenCapacityAvailableAsync(items, itemsByPartition, cancellationToken);
     }
 
     private bool TryEnqueue(T item)
@@ -48,9 +134,8 @@ internal sealed class MemoryBufferProducer<T>(
         var capacityGate = _capacityGate;
         if (capacityGate == null)
         {
-            var unboundedPartition = Append(item, out _);
-
-            unboundedPartition.NotifyConsumers();
+            var partition = Append(item);
+            partition.NotifyConsumers();
             return true;
         }
 
@@ -60,6 +145,56 @@ internal sealed class MemoryBufferProducer<T>(
         }
 
         return TryEnqueueConcurrent(item, capacityGate);
+    }
+
+    private bool TryEnqueueSerialized(
+        T item,
+        MemoryBufferCapacityGate capacityGate,
+        object appendLock)
+    {
+        MemoryBufferPartition<T> partition;
+        lock (appendLock)
+        {
+            if (!capacityGate.TryAcquire())
+            {
+                return false;
+            }
+
+            try
+            {
+                partition = AppendSelectedPartition(item);
+            }
+            catch
+            {
+                capacityGate.Release();
+                throw;
+            }
+        }
+
+        partition.NotifyConsumers();
+        return true;
+    }
+
+    private bool TryEnqueueConcurrent(T item, MemoryBufferCapacityGate capacityGate)
+    {
+        if (!capacityGate.TryAcquire())
+        {
+            return false;
+        }
+
+        MemoryBufferPartition<T> partition;
+        try
+        {
+            partition = Append(item);
+        }
+        catch
+        {
+            capacityGate?.Release();
+            throw;
+        }
+
+        partition.NotifyConsumers();
+        return true;
     }
 
     private bool TryEnqueueBatch(ReadOnlySpan<T> items)
@@ -74,140 +209,126 @@ internal sealed class MemoryBufferProducer<T>(
             return TryEnqueue(items[0]);
         }
 
-        return _serializedAppendLock is { } serializedAppendLock
-            ? TryEnqueueBatchSerialized(items, serializedAppendLock)
-            : TryEnqueueBatchConcurrent(items);
-    }
-
-    private bool TryEnqueueSerialized(T item, MemoryBufferCapacityGate capacityGate, object appendLock)
-    {
-        MemoryBufferPartition<T> partition;
-        lock (appendLock)
-        {
-            if (!capacityGate.TryAcquire())
-            {
-                return false;
-            }
-
-            ulong reclaimedCount;
-            try
-            {
-                partition = AppendSelectedPartition(item, out reclaimedCount);
-            }
-            catch
-            {
-                capacityGate.Release();
-                throw;
-            }
-
-            capacityGate.Release(reclaimedCount);
-        }
-
-        partition.NotifyConsumers();
-        return true;
-    }
-
-    private bool TryEnqueueBatchSerialized(ReadOnlySpan<T> items, object appendLock)
-    {
-        var modifiedPartitions = partitions.Length <= 128
-            ? stackalloc bool[partitions.Length]
-            : new bool[partitions.Length];
         var capacityGate = _capacityGate;
-
-        try
-        {
-            lock (appendLock)
-            {
-                if (capacityGate != null && !capacityGate.TryAcquire((ulong)items.Length))
-                {
-                    return false;
-                }
-
-                var appendedCount = 0;
-                ulong reclaimedCount = 0;
-                try
-                {
-                    foreach (var item in items)
-                    {
-                        var partitionIndex = SelectPartitionIndex(item);
-                        reclaimedCount += partitions[partitionIndex].AppendFromSerializedProducer(item);
-                        modifiedPartitions[partitionIndex] = true;
-                        appendedCount++;
-                    }
-                }
-                catch
-                {
-                    capacityGate?.Release((ulong)(items.Length - appendedCount) + reclaimedCount);
-                    throw;
-                }
-
-                capacityGate?.Release(reclaimedCount);
-            }
-        }
-        finally
-        {
-            NotifyConsumers(modifiedPartitions);
-        }
-
-        return true;
-    }
-
-    private bool TryEnqueueConcurrent(T item, MemoryBufferCapacityGate capacityGate)
-    {
-        if (!capacityGate.TryAcquire())
+        if (capacityGate != null && (ulong)items.Length > capacityGate.Capacity)
         {
             return false;
         }
 
-        MemoryBufferPartition<T> partition;
-        var appended = false;
-        try
+        if (_serializedAppendLock != null)
         {
-            partition = Append(item, out var reclaimedCount);
-            appended = true;
-            capacityGate.Release(reclaimedCount);
-        }
-        catch
-        {
-            if (!appended)
-            {
-                capacityGate.Release();
-            }
-
-            throw;
+            return TryEnqueueBatchSerialized(items);
         }
 
-        partition.NotifyConsumers();
-        return true;
+        var itemsByPartition = GroupItemsByPartition(items);
+        return TryEnqueueBatchConcurrent(itemsByPartition, items.Length);
     }
 
-    private bool TryEnqueueBatchConcurrent(ReadOnlySpan<T> items)
+    private bool TryEnqueueBatchSerialized(ReadOnlySpan<T> items)
     {
-        var itemsByPartition = new List<T>?[partitions.Length];
-        foreach (var item in items)
-        {
-            var partitionIndex = SelectPartitionIndex(item);
-            var partitionItems = itemsByPartition[partitionIndex];
-            if (partitionItems == null)
-            {
-                partitionItems = [];
-                itemsByPartition[partitionIndex] = partitionItems;
-            }
-
-            partitionItems.Add(item);
-        }
-
         var capacityGate = _capacityGate;
         if (capacityGate != null && !capacityGate.TryAcquire((ulong)items.Length))
         {
             return false;
         }
 
+        AppendBatchSerialized(items, capacityGate);
+        return true;
+    }
+
+    private bool TryEnqueueBatchConcurrent(List<T>?[] itemsByPartition, int itemCount)
+    {
+        var capacityGate = _capacityGate;
+        if (capacityGate != null && !capacityGate.TryAcquire((ulong)itemCount))
+        {
+            return false;
+        }
+
+        AppendBatchConcurrent(itemsByPartition, itemCount, capacityGate);
+        return true;
+    }
+
+    private async ValueTask EnqueueWhenCapacityAvailableAsync(
+        T item,
+        CancellationToken cancellationToken)
+    {
+        var capacityGate = _capacityGate!;
+        await capacityGate.AcquireAsync(1, cancellationToken).ConfigureAwait(false);
+
+        MemoryBufferPartition<T> partition;
+        try
+        {
+            partition = Append(item);
+        }
+        catch
+        {
+            capacityGate.Release();
+            throw;
+        }
+
+        partition.NotifyConsumers();
+    }
+
+    private async ValueTask EnqueueBatchWhenCapacityAvailableAsync(
+        ReadOnlyMemory<T> items,
+        List<T>?[]? itemsByPartition,
+        CancellationToken cancellationToken)
+    {
+        var capacityGate = _capacityGate!;
+        await capacityGate.AcquireAsync((ulong)items.Length, cancellationToken).ConfigureAwait(false);
+
+        if (itemsByPartition == null)
+        {
+            AppendBatchSerialized(items.Span, capacityGate);
+        }
+        else
+        {
+            AppendBatchConcurrent(itemsByPartition, items.Length, capacityGate);
+        }
+    }
+
+    private void AppendBatchSerialized(
+        ReadOnlySpan<T> items,
+        MemoryBufferCapacityGate? capacityGate)
+    {
         var modifiedPartitions = partitions.Length <= 128
             ? stackalloc bool[partitions.Length]
             : new bool[partitions.Length];
         var appendedCount = 0;
-        ulong reclaimedCount = 0;
+
+        try
+        {
+            lock (_serializedAppendLock!)
+            {
+                foreach (var item in items)
+                {
+                    var partitionIndex = SelectPartitionIndex(item);
+                    partitions[partitionIndex].AppendFromSerializedProducer(item);
+                    modifiedPartitions[partitionIndex] = true;
+                    appendedCount++;
+                }
+            }
+        }
+        catch
+        {
+            capacityGate?.Release((ulong)(items.Length - appendedCount));
+            throw;
+        }
+        finally
+        {
+            NotifyConsumers(modifiedPartitions);
+        }
+    }
+
+    private void AppendBatchConcurrent(
+        List<T>?[] itemsByPartition,
+        int itemCount,
+        MemoryBufferCapacityGate? capacityGate)
+    {
+        var modifiedPartitions = partitions.Length <= 128
+            ? stackalloc bool[partitions.Length]
+            : new bool[partitions.Length];
+        var appendedCount = 0;
 
         try
         {
@@ -225,50 +346,65 @@ internal sealed class MemoryBufferProducer<T>(
                 {
                     foreach (var item in partitionItems)
                     {
-                        reclaimedCount += partition.AppendFromSerializedProducer(item);
+                        partition.AppendFromSerializedProducer(item);
                         appendedCount++;
                     }
                 }
             }
-
-            capacityGate?.Release(reclaimedCount);
         }
         catch
         {
-            capacityGate?.Release((ulong)(items.Length - appendedCount) + reclaimedCount);
+            capacityGate?.Release((ulong)(itemCount - appendedCount));
             throw;
         }
         finally
         {
             NotifyConsumers(modifiedPartitions);
         }
-
-        return true;
     }
 
-    private MemoryBufferPartition<T> Append(T item, out ulong reclaimedCount)
+    private List<T>?[] GroupItemsByPartition(ReadOnlySpan<T> items)
+    {
+        var itemsByPartition = new List<T>?[partitions.Length];
+        foreach (var item in items)
+        {
+            var partitionIndex = SelectPartitionIndex(item);
+            var partitionItems = itemsByPartition[partitionIndex];
+            if (partitionItems == null)
+            {
+                partitionItems = [];
+                itemsByPartition[partitionIndex] = partitionItems;
+            }
+
+            partitionItems.Add(item);
+        }
+
+        return itemsByPartition;
+    }
+
+    private MemoryBufferPartition<T> Append(T item)
     {
         if (_serializedAppendLock is { } serializedAppendLock)
         {
             lock (serializedAppendLock)
             {
-                return AppendSelectedPartition(item, out reclaimedCount);
+                return AppendSelectedPartition(item);
             }
         }
 
         var partition = SelectPartition(item);
         lock (partition.AppendLock)
         {
-            reclaimedCount = partition.AppendFromSerializedProducer(item);
+            partition.AppendFromSerializedProducer(item);
         }
 
         return partition;
     }
 
-    private MemoryBufferPartition<T> AppendSelectedPartition(T item, out ulong reclaimedCount)
+    private MemoryBufferPartition<T> AppendSelectedPartition(T item)
     {
         var partition = SelectPartition(item);
-        reclaimedCount = partition.AppendFromSerializedProducer(item);
+        partition.AppendFromSerializedProducer(item);
         return partition;
     }
 
@@ -285,6 +421,28 @@ internal sealed class MemoryBufferProducer<T>(
                 partitions[partitionIndex].NotifyConsumers();
             }
         }
+    }
+
+    private BufferQueueFullException CreateQueueFullException(string subject) =>
+        new($"The queue '{TopicName}' is full, and the {subject} cannot be produced.");
+
+    private static MemoryBufferCapacityGate? CreateCapacityGate(
+        MemoryBufferQueueOptions options,
+        MemoryBufferPartition<T>[] bufferPartitions)
+    {
+        if (options.BoundedCapacity is not { } capacity)
+        {
+            return null;
+        }
+
+        var capacityGate = new MemoryBufferCapacityGate(capacity);
+        Action<ulong> releaseCapacity = capacityGate.Release;
+        foreach (var partition in bufferPartitions)
+        {
+            partition.SetCapacityReleaseHandler(releaseCapacity);
+        }
+
+        return capacityGate;
     }
 
     private static object GetSharedAppendLock(MemoryBufferPartition<T>[] bufferPartitions)

--- a/src/BufferQueue/Memory/MemoryBufferQueue.cs
+++ b/src/BufferQueue/Memory/MemoryBufferQueue.cs
@@ -12,7 +12,10 @@ internal sealed class MemoryBufferQueue<T> : BufferQueue<T>
     }
 
     internal MemoryBufferQueue(MemoryBufferQueueOptions options, IPartitioner<T> partitioner)
-        : this(options, partitioner, CreatePartitions(options, partitioner.SupportsConcurrentSelection))
+        : this(
+            options.Validate(),
+            partitioner,
+            CreatePartitions(options, partitioner.SupportsConcurrentSelection))
     {
     }
 

--- a/src/BufferQueue/Memory/MemoryBufferQueueOptions.cs
+++ b/src/BufferQueue/Memory/MemoryBufferQueueOptions.cs
@@ -24,11 +24,43 @@ public class MemoryBufferQueueOptions
     /// The maximum capacity of the bounded memory buffer queue. Default is null, which means unbounded.
     /// </summary>
     /// <remarks>
-    /// If set, the non-try producer extension will throw a <see cref="BufferQueueFullException"/> when the queue
-    /// is full, and
-    /// <see cref="IBufferProducer{T}.TryProduceAsync(T)"/> will return false when the queue is full.
+    /// When set, <see cref="FullMode"/> controls how <see cref="IBufferProducer{T}.ProduceAsync(T, CancellationToken)"/>
+    /// behaves when the queue is full. <see cref="IBufferProducer{T}.TryProduceAsync(T, CancellationToken)"/> always
+    /// returns false immediately when capacity is unavailable.
     /// </remarks>
     public ulong? BoundedCapacity { get; set; }
+
+    /// <summary>
+    /// Controls how a bounded queue handles writes when capacity is unavailable. Default is Wait.
+    /// </summary>
+    public BufferQueueFullMode FullMode { get; set; } = BufferQueueFullMode.Wait;
+
+    internal MemoryBufferQueueOptions Validate()
+    {
+        if (string.IsNullOrWhiteSpace(TopicName))
+        {
+            throw new ArgumentException("Topic name cannot be null or whitespace.", nameof(TopicName));
+        }
+
+        if (PartitionNumber <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(PartitionNumber),
+                "Partition number must be greater than zero.");
+        }
+
+        if (BoundedCapacity == 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(BoundedCapacity),
+                "Bounded capacity must be greater than zero.");
+        }
+
+        if (!Enum.IsDefined(FullMode))
+        {
+            throw new ArgumentOutOfRangeException(nameof(FullMode), "The full mode is not supported.");
+        }
+
+        return this;
+    }
 }
 
 public class MemoryBufferQueueOptions<T> : MemoryBufferQueueOptions

--- a/tests/BufferQueue.MemoryMappedFile.Tests/MemoryMappedFileBufferProducerTests.cs
+++ b/tests/BufferQueue.MemoryMappedFile.Tests/MemoryMappedFileBufferProducerTests.cs
@@ -1,0 +1,151 @@
+using System.Text.Json;
+
+namespace BufferQueue.MemoryMappedFile.Tests;
+
+public class MemoryMappedFileBufferProducerTests
+{
+    [Fact]
+    public async Task TryProduceAsync_Batch_Writes_All_Items()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var queue = CreateQueue(temporaryDirectory.Path);
+        var producer = queue.GetProducer();
+
+        Assert.True(await producer.TryProduceAsync(new[] { 1, 2, 3 }.AsMemory()));
+
+        Assert.Equal(new[] { 1, 2, 3 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    [Fact]
+    public async Task TryProduceAsync_Canceled_Single_Does_Not_Write()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var queue = CreateQueue(temporaryDirectory.Path);
+        var producer = queue.GetProducer();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.TryProduceAsync(1, cancellationTokenSource.Token));
+
+        await producer.ProduceAsync(2);
+        Assert.Equal(new[] { 2 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    [Fact]
+    public async Task TryProduceAsync_Canceled_Batch_Does_Not_Write()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var queue = CreateQueue(temporaryDirectory.Path);
+        var producer = queue.GetProducer();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.TryProduceAsync(new[] { 1, 2, 3 }.AsMemory(), cancellationTokenSource.Token));
+
+        await producer.ProduceAsync(4);
+        Assert.Equal(new[] { 4 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Canceled_Single_Does_Not_Write()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var queue = CreateQueue(temporaryDirectory.Path);
+        var producer = queue.GetProducer();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.ProduceAsync(1, cancellationTokenSource.Token));
+
+        await producer.ProduceAsync(2);
+        Assert.Equal(new[] { 2 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Canceled_Batch_Does_Not_Write()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var queue = CreateQueue(temporaryDirectory.Path);
+        var producer = queue.GetProducer();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.ProduceAsync(new[] { 1, 2, 3 }.AsMemory(), cancellationTokenSource.Token));
+
+        await producer.ProduceAsync(4);
+        Assert.Equal(new[] { 4 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Batch_Does_Not_Recheck_Cancellation_During_Write()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        var options = CreateOptions(temporaryDirectory.Path);
+        options.Serializer = new CancelOnFirstSerializeMemoryMappedFileSerializer(cancellationTokenSource);
+        using var queue = new MemoryMappedFileBufferQueue<int>(options);
+        var producer = queue.GetProducer();
+
+        await producer.ProduceAsync(new[] { 1, 2, 3 }.AsMemory(), cancellationTokenSource.Token);
+
+        Assert.Equal(new[] { 1, 2, 3 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    private static MemoryMappedFileBufferQueue<int> CreateQueue(string dataDirectory) =>
+        new(new MemoryMappedFileBufferQueueOptions<int>
+        {
+            TopicName = "test",
+            DataDirectory = dataDirectory,
+            SegmentSizeInBytes = 1024
+        });
+
+    private static MemoryMappedFileBufferQueueOptions<int> CreateOptions(string dataDirectory) =>
+        new()
+        {
+            TopicName = "test",
+            DataDirectory = dataDirectory,
+            SegmentSizeInBytes = 1024
+        };
+
+    private static async Task<int[]> ConsumeOneBatchAsync(MemoryMappedFileBufferQueue<int> queue)
+    {
+        var consumer = queue.CreateConsumer(new BufferPullConsumerOptions
+        {
+            TopicName = "test",
+            GroupName = "test-group",
+            AutoCommit = true,
+            BatchSize = 10
+        });
+
+        await foreach (var items in consumer.ConsumeAsync())
+        {
+            return items.ToArray();
+        }
+
+        throw new InvalidOperationException("The consumer completed without returning a batch.");
+    }
+
+    private sealed class CancelOnFirstSerializeMemoryMappedFileSerializer(
+        CancellationTokenSource cancellationTokenSource)
+        : IMemoryMappedFileSerializer<int>
+    {
+        private int _serializeCount;
+
+        public byte[] Serialize(int item)
+        {
+            if (Interlocked.Increment(ref _serializeCount) == 1)
+            {
+                cancellationTokenSource.Cancel();
+            }
+
+            return JsonSerializer.SerializeToUtf8Bytes(item);
+        }
+
+        public int Deserialize(ReadOnlyMemory<byte> payload) =>
+            JsonSerializer.Deserialize<int>(payload.Span);
+    }
+}

--- a/tests/BufferQueue.MemoryMappedFile.Tests/MemoryMappedFileBufferProducerTests.cs
+++ b/tests/BufferQueue.MemoryMappedFile.Tests/MemoryMappedFileBufferProducerTests.cs
@@ -5,6 +5,18 @@ namespace BufferQueue.MemoryMappedFile.Tests;
 public class MemoryMappedFileBufferProducerTests
 {
     [Fact]
+    public async Task TryProduceAsync_Single_Writes_Item()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        using var queue = CreateQueue(temporaryDirectory.Path);
+        var producer = queue.GetProducer();
+
+        Assert.True(await producer.TryProduceAsync(1));
+
+        Assert.Equal(new[] { 1 }, await ConsumeOneBatchAsync(queue));
+    }
+
+    [Fact]
     public async Task TryProduceAsync_Batch_Writes_All_Items()
     {
         using var temporaryDirectory = new TemporaryDirectory();

--- a/tests/BufferQueue.MemoryMappedFile.Tests/MemoryMappedFileBufferQueueOptionsTests.cs
+++ b/tests/BufferQueue.MemoryMappedFile.Tests/MemoryMappedFileBufferQueueOptionsTests.cs
@@ -1,0 +1,83 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BufferQueue.MemoryMappedFile.Tests;
+
+public class MemoryMappedFileBufferQueueOptionsTests
+{
+    [Fact]
+    public void Validate_Returns_Options_When_Valid()
+    {
+        var options = new MemoryMappedFileBufferQueueOptions<int>
+        {
+            TopicName = "test"
+        };
+
+        Assert.Same(options, options.Validate());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_Throws_When_Topic_Name_Is_Missing(string? topicName)
+    {
+        var options = new MemoryMappedFileBufferQueueOptions<int>
+        {
+            TopicName = topicName
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => options.Validate());
+
+        Assert.Equal("TopicName", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_Throws_When_Partition_Number_Is_Not_Positive(int partitionNumber)
+    {
+        var options = new MemoryMappedFileBufferQueueOptions<int>
+        {
+            TopicName = "test",
+            PartitionNumber = partitionNumber
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+
+        Assert.Equal("PartitionNumber", exception.ParamName);
+    }
+
+    [Fact]
+    public void AddTopic_Validates_Options_Immediately()
+    {
+        var services = new ServiceCollection();
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new MemoryMappedFileBufferOptionsBuilder(services).AddTopic<int>(options =>
+            {
+                options.TopicName = "test";
+                options.SegmentSizeInBytes = 0;
+            }));
+
+        Assert.Equal("SegmentSizeInBytes", exception.ParamName);
+        Assert.Empty(services);
+    }
+
+    [Fact]
+    public void Queue_Validates_Options_Before_Creating_Partitions()
+    {
+        using var temporaryDirectory = new TemporaryDirectory();
+        var options = new MemoryMappedFileBufferQueueOptions<int>
+        {
+            TopicName = "test",
+            DataDirectory = temporaryDirectory.Path,
+            PartitionNumber = 0
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new MemoryMappedFileBufferQueue<int>(options));
+
+        Assert.Equal("PartitionNumber", exception.ParamName);
+        Assert.False(Directory.Exists(Path.Combine(temporaryDirectory.Path, "test")));
+    }
+}

--- a/tests/BufferQueue.Tests/Memory/MemoryBufferCapacityGateTests.cs
+++ b/tests/BufferQueue.Tests/Memory/MemoryBufferCapacityGateTests.cs
@@ -84,6 +84,48 @@ public class MemoryBufferCapacityGateTests
     }
 
     [Fact]
+    public void TryAcquire_Zero_Count_Succeeds_Without_Capacity()
+    {
+        var gate = new MemoryBufferCapacityGate(0);
+
+        Assert.True(gate.TryAcquire(0));
+    }
+
+    [Fact]
+    public void AcquireAsync_Count_Exceeding_Capacity_Throws()
+    {
+        var gate = new MemoryBufferCapacityGate(2);
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => gate.AcquireAsync(3, default));
+
+        Assert.Equal("count", exception.ParamName);
+    }
+
+    [Fact]
+    public async Task AcquireAsync_Zero_Count_Completes_Immediately()
+    {
+        var gate = new MemoryBufferCapacityGate(0);
+
+        var acquisition = gate.AcquireAsync(0, default);
+
+        Assert.True(acquisition.IsCompletedSuccessfully);
+        await acquisition;
+    }
+
+    [Fact]
+    public async Task AcquireAsync_Completes_Immediately_When_Capacity_Is_Available()
+    {
+        var gate = new MemoryBufferCapacityGate(2);
+
+        var acquisition = gate.AcquireAsync(2, default);
+
+        Assert.True(acquisition.IsCompletedSuccessfully);
+        await acquisition;
+        Assert.False(gate.TryAcquire());
+    }
+
+    [Fact]
     public void Release_Makes_Capacity_Available_Again()
     {
         var gate = new MemoryBufferCapacityGate(2);

--- a/tests/BufferQueue.Tests/Memory/MemoryBufferCapacityGateTests.cs
+++ b/tests/BufferQueue.Tests/Memory/MemoryBufferCapacityGateTests.cs
@@ -107,4 +107,73 @@ public class MemoryBufferCapacityGateTests
 
         Assert.Equal("Cannot release more bounded queue capacity than was acquired.", exception.Message);
     }
+
+    [Fact]
+    public async Task AcquireAsync_Completes_After_Capacity_Is_Released()
+    {
+        var gate = new MemoryBufferCapacityGate(1);
+        Assert.True(gate.TryAcquire());
+
+        var waitingTask = gate.AcquireAsync(1, default).AsTask();
+        Assert.False(waitingTask.IsCompleted);
+
+        gate.Release();
+
+        await waitingTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(gate.TryAcquire());
+    }
+
+    [Fact]
+    public async Task AcquireAsync_Uses_Whole_Batch_Fifo_Admission()
+    {
+        var gate = new MemoryBufferCapacityGate(3);
+        Assert.True(gate.TryAcquire(3));
+
+        var batchTask = gate.AcquireAsync(3, default).AsTask();
+        var singleTask = gate.AcquireAsync(1, default).AsTask();
+
+        gate.Release();
+
+        Assert.False(batchTask.IsCompleted);
+        Assert.False(singleTask.IsCompleted);
+        Assert.False(gate.TryAcquire());
+
+        gate.Release(2);
+        await batchTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(singleTask.IsCompleted);
+
+        gate.Release();
+        await singleTask.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task Canceling_Head_Waiter_Allows_Next_Waiter_To_Proceed()
+    {
+        var gate = new MemoryBufferCapacityGate(2);
+        Assert.True(gate.TryAcquire(2));
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var batchTask = gate.AcquireAsync(2, cancellationTokenSource.Token).AsTask();
+        var singleTask = gate.AcquireAsync(1, default).AsTask();
+        gate.Release();
+
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await batchTask);
+        await singleTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.False(gate.TryAcquire());
+    }
+
+    [Fact]
+    public async Task AcquireAsync_Observes_Cancellation_Without_Consuming_Capacity()
+    {
+        var gate = new MemoryBufferCapacityGate(1);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () =>
+            await gate.AcquireAsync(1, cancellationTokenSource.Token));
+
+        Assert.True(gate.TryAcquire());
+    }
 }

--- a/tests/BufferQueue.Tests/Memory/MemoryBufferProducerTests.cs
+++ b/tests/BufferQueue.Tests/Memory/MemoryBufferProducerTests.cs
@@ -42,6 +42,24 @@ public class MemoryBufferProducerTests
     }
 
     [Fact]
+    public async Task Canceled_IEnumerable_Batch_Does_Not_Enumerate_The_Input()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        IBufferProducer<int> producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions { TopicName = "test" },
+            [partition]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.ProduceAsync(ThrowWhenEnumerated(), cancellationTokenSource.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.TryProduceAsync(ThrowWhenEnumerated(), cancellationTokenSource.Token));
+
+        Assert.Equal(0UL, partition.Count);
+    }
+
+    [Fact]
     public async Task ProduceAsync_Batch_RoundRobin_Routes_Each_Item_To_The_Next_Partition()
     {
         var appendLock = new object();
@@ -84,20 +102,206 @@ public class MemoryBufferProducerTests
     }
 
     [Fact]
-    public async Task ProduceAsync_Batch_WithoutEnoughBoundedCapacity_Throws_WithoutAppending_A_PartialBatch()
+    public async Task ProduceAsync_Batch_In_Fail_Mode_WithoutEnoughCapacity_Throws_WithoutAppending_A_PartialBatch()
     {
         var partition = new MemoryBufferPartition<int>(0, 8);
         IBufferProducer<int> producer = new MemoryBufferProducer<int>(
             new MemoryBufferQueueOptions
             {
                 TopicName = "test",
-                BoundedCapacity = 2
+                BoundedCapacity = 2,
+                FullMode = BufferQueueFullMode.Fail
             },
             [partition]);
         var items = new[] { 1, 2, 3 };
 
         await Assert.ThrowsAsync<BufferQueueFullException>(async () =>
             await producer.ProduceAsync(items.AsMemory()));
+
+        Assert.Equal(0UL, partition.Count);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Wait_Mode_Completes_After_Exact_Full_Capacity_Is_Committed()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 1,
+                FullMode = BufferQueueFullMode.Wait
+            },
+            [partition]);
+
+        await producer.ProduceAsync(1);
+        var waitingTask = producer.ProduceAsync(2).AsTask();
+
+        Assert.False(waitingTask.IsCompleted);
+        Assert.False(await producer.TryProduceAsync(3));
+        Assert.True(partition.TryPull("TestGroup", 1, out var firstBatch));
+        Assert.Equal(new[] { 1 }, firstBatch);
+
+        partition.Commit("TestGroup");
+
+        await waitingTask.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(partition.TryPull("TestGroup", 1, out var secondBatch));
+        Assert.Equal(new[] { 2 }, secondBatch);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Wait_Mode_Cancellation_Does_Not_Write_Or_Lose_Capacity()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 1,
+                FullMode = BufferQueueFullMode.Wait
+            },
+            [partition]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await producer.ProduceAsync(1);
+        var canceledWrite = producer.ProduceAsync(2, cancellationTokenSource.Token).AsTask();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await canceledWrite);
+        Assert.True(partition.TryPull("TestGroup", 1, out var firstBatch));
+        Assert.Equal(new[] { 1 }, firstBatch);
+        partition.Commit("TestGroup");
+
+        Assert.True(await producer.TryProduceAsync(3));
+        Assert.True(partition.TryPull("TestGroup", 1, out var secondBatch));
+        Assert.Equal(new[] { 3 }, secondBatch);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Wait_Mode_Batch_Waits_For_The_Whole_Capacity()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 3,
+                FullMode = BufferQueueFullMode.Wait
+            },
+            [partition]);
+
+        await producer.ProduceAsync(new[] { 1, 2 }.AsMemory());
+        var waitingBatch = producer.ProduceAsync(new[] { 3, 4 }.AsMemory()).AsTask();
+        Assert.False(waitingBatch.IsCompleted);
+
+        Assert.True(partition.TryPull("TestGroup", 1, out var firstBatch));
+        Assert.Equal(new[] { 1 }, firstBatch);
+        partition.Commit("TestGroup");
+
+        await waitingBatch.WaitAsync(TimeSpan.FromSeconds(10));
+        Assert.True(partition.TryPull("TestGroup", 3, out var remainingItems));
+        Assert.Equal(new[] { 2, 3, 4 }, remainingItems);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Wait_Mode_Rejects_A_Batch_Larger_Than_Capacity()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 2,
+                FullMode = BufferQueueFullMode.Wait
+            },
+            [partition]);
+
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+            await producer.ProduceAsync(new[] { 1, 2, 3 }.AsMemory()));
+
+        Assert.Equal("items", exception.ParamName);
+        Assert.Equal(0UL, partition.Count);
+    }
+
+    [Fact]
+    public async Task Capacity_Is_Released_Only_After_All_Known_Groups_Commit()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 1,
+                FullMode = BufferQueueFullMode.Wait
+            },
+            [partition]);
+
+        await producer.ProduceAsync(1);
+        Assert.True(partition.TryPull("Group1", 1, out _));
+        Assert.True(partition.TryPull("Group2", 1, out _));
+        var waitingTask = producer.ProduceAsync(2).AsTask();
+
+        partition.Commit("Group1");
+        Assert.False(waitingTask.IsCompleted);
+
+        partition.Commit("Group2");
+        await waitingTask.WaitAsync(TimeSpan.FromSeconds(10));
+    }
+
+    [Fact]
+    public async Task New_Group_Starts_After_Capacity_Already_Released()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 1
+            },
+            [partition]);
+
+        await producer.ProduceAsync(1);
+        Assert.True(partition.TryPull("Group1", 1, out _));
+        partition.Commit("Group1");
+        await producer.ProduceAsync(2);
+
+        Assert.True(partition.TryPull("Group2", 1, out var items));
+        Assert.Equal(new[] { 2 }, items);
+    }
+
+    [Fact]
+    public async Task New_Group_Skips_Multiple_Segments_Before_The_Released_Position()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 2);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 5
+            },
+            [partition]);
+
+        await producer.ProduceAsync(new[] { 1, 2, 3, 4, 5 }.AsMemory());
+        Assert.True(partition.TryPull("Group1", 5, out _));
+        partition.Commit("Group1");
+        await producer.ProduceAsync(6);
+
+        Assert.True(partition.TryPull("Group2", 1, out var items));
+        Assert.Equal(new[] { 6 }, items);
+    }
+
+    [Fact]
+    public async Task Canceled_TryProduceAsync_Does_Not_Write()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions { TopicName = "test" },
+            [partition]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await producer.TryProduceAsync(1, cancellationTokenSource.Token));
 
         Assert.Equal(0UL, partition.Count);
     }
@@ -499,6 +703,13 @@ public class MemoryBufferProducerTests
     {
         Assert.True(partition.TryPull($"TestGroup-{partition.PartitionId}", 16, out var items));
         Assert.Equal(expectedItems, items);
+    }
+
+    private static IEnumerable<int> ThrowWhenEnumerated()
+    {
+        yield return Throw();
+
+        static int Throw() => throw new InvalidOperationException("The input must not be enumerated.");
     }
 
     private static void AssertNumericPartition<TNumber>(TNumber partitionKey, int expectedPartitionIndex)

--- a/tests/BufferQueue.Tests/Memory/MemoryBufferProducerTests.cs
+++ b/tests/BufferQueue.Tests/Memory/MemoryBufferProducerTests.cs
@@ -42,6 +42,38 @@ public class MemoryBufferProducerTests
     }
 
     [Fact]
+    public async Task TryProduceAsync_IEnumerable_Batch_Appends_All_Items_In_Order()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        IBufferProducer<int> producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions { TopicName = "test" },
+            [partition]);
+        var expectedItems = Enumerable.Range(1, 4);
+
+        Assert.True(await producer.TryProduceAsync(expectedItems));
+
+        Assert.True(partition.TryPull("TestGroup", 4, out var items));
+        Assert.Equal(expectedItems, items);
+    }
+
+    [Fact]
+    public async Task ReadOnlyMemory_Empty_And_Single_Item_Batches_Are_Supported()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        IBufferProducer<int> producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions { TopicName = "test" },
+            [partition]);
+
+        await producer.ProduceAsync(ReadOnlyMemory<int>.Empty);
+        Assert.True(await producer.TryProduceAsync(ReadOnlyMemory<int>.Empty));
+        await producer.ProduceAsync(new[] { 1 }.AsMemory());
+        Assert.True(await producer.TryProduceAsync(new[] { 2 }.AsMemory()));
+
+        Assert.True(partition.TryPull("TestGroup", 2, out var items));
+        Assert.Equal(new[] { 1, 2 }, items);
+    }
+
+    [Fact]
     public async Task Canceled_IEnumerable_Batch_Does_Not_Enumerate_The_Input()
     {
         var partition = new MemoryBufferPartition<int>(0, 8);
@@ -119,6 +151,48 @@ public class MemoryBufferProducerTests
             await producer.ProduceAsync(items.AsMemory()));
 
         Assert.Equal(0UL, partition.Count);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Single_In_Fail_Mode_Throws_When_The_Queue_Is_Full()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        IBufferProducer<int> producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 1,
+                FullMode = BufferQueueFullMode.Fail
+            },
+            [partition]);
+
+        await producer.ProduceAsync(1);
+
+        await Assert.ThrowsAsync<BufferQueueFullException>(async () => await producer.ProduceAsync(2));
+        Assert.Equal(1UL, partition.Count);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_PartitionKey_Batch_In_Fail_Mode_Requires_The_Whole_Capacity()
+    {
+        var options = new MemoryBufferQueueOptions<int>
+        {
+            TopicName = "test",
+            PartitionNumber = 2,
+            BoundedCapacity = 2,
+            FullMode = BufferQueueFullMode.Fail
+        };
+        options.UsePartitionKey(static item => item);
+        var partitions = Enumerable.Range(0, options.PartitionNumber)
+            .Select(index => new MemoryBufferPartition<int>(index, 8))
+            .ToArray();
+        IBufferProducer<int> producer = new MemoryBufferProducer<int>(options, partitions);
+
+        await producer.ProduceAsync(1);
+
+        await Assert.ThrowsAsync<BufferQueueFullException>(async () =>
+            await producer.ProduceAsync(new[] { 2, 3 }.AsMemory()));
+        Assert.Equal(1UL, partitions.Aggregate(0UL, (count, partition) => count + partition.Count));
     }
 
     [Fact]
@@ -201,6 +275,65 @@ public class MemoryBufferProducerTests
         await waitingBatch.WaitAsync(TimeSpan.FromSeconds(10));
         Assert.True(partition.TryPull("TestGroup", 3, out var remainingItems));
         Assert.Equal(new[] { 2, 3, 4 }, remainingItems);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Wait_Mode_PartitionKey_Batch_Resumes_Across_Partitions()
+    {
+        var options = new MemoryBufferQueueOptions<int>
+        {
+            TopicName = "test",
+            PartitionNumber = 2,
+            BoundedCapacity = 3,
+            FullMode = BufferQueueFullMode.Wait
+        };
+        options.UsePartitionKey(static item => item);
+        var partitions = Enumerable.Range(0, options.PartitionNumber)
+            .Select(index => new MemoryBufferPartition<int>(index, 8))
+            .ToArray();
+        var producer = new MemoryBufferProducer<int>(options, partitions);
+
+        await producer.ProduceAsync(new[] { 1, 2 }.AsMemory());
+        var waitingBatch = producer.ProduceAsync(new[] { 3, 4 }.AsMemory()).AsTask();
+        Assert.False(waitingBatch.IsCompleted);
+
+        Assert.True(partitions[0].TryPull("TestGroup", 1, out var firstBatch));
+        Assert.Equal(new[] { 1 }, firstBatch);
+        partitions[0].Commit("TestGroup");
+
+        await waitingBatch.WaitAsync(TimeSpan.FromSeconds(10));
+        AssertPartitionItems(partitions[0], 3);
+        AssertPartitionItems(partitions[1], 2, 4);
+    }
+
+    [Fact]
+    public async Task ProduceAsync_Wait_Mode_Batch_Cancellation_Does_Not_Write_Or_Lose_Capacity()
+    {
+        var partition = new MemoryBufferPartition<int>(0, 8);
+        var producer = new MemoryBufferProducer<int>(
+            new MemoryBufferQueueOptions
+            {
+                TopicName = "test",
+                BoundedCapacity = 2,
+                FullMode = BufferQueueFullMode.Wait
+            },
+            [partition]);
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        await producer.ProduceAsync(1);
+        var canceledBatch = producer
+            .ProduceAsync(new[] { 2, 3 }.AsMemory(), cancellationTokenSource.Token)
+            .AsTask();
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await canceledBatch);
+        Assert.True(partition.TryPull("TestGroup", 1, out var firstBatch));
+        Assert.Equal(new[] { 1 }, firstBatch);
+        partition.Commit("TestGroup");
+
+        Assert.True(await producer.TryProduceAsync(new[] { 4, 5 }.AsMemory()));
+        Assert.True(partition.TryPull("TestGroup", 2, out var secondBatch));
+        Assert.Equal(new[] { 4, 5 }, secondBatch);
     }
 
     [Fact]

--- a/tests/BufferQueue.Tests/Memory/MemoryBufferQueueOptionsTests.cs
+++ b/tests/BufferQueue.Tests/Memory/MemoryBufferQueueOptionsTests.cs
@@ -1,0 +1,85 @@
+using BufferQueue.Memory;
+
+namespace BufferQueue.Tests.Memory;
+
+public class MemoryBufferQueueOptionsTests
+{
+    [Fact]
+    public void Full_Mode_Defaults_To_Wait()
+    {
+        var options = new MemoryBufferQueueOptions();
+
+        Assert.Equal(BufferQueueFullMode.Wait, options.FullMode);
+    }
+
+    [Fact]
+    public void Validate_Returns_Options_When_Valid()
+    {
+        var options = new MemoryBufferQueueOptions
+        {
+            TopicName = "test",
+            PartitionNumber = 2
+        };
+
+        var validatedOptions = options.Validate();
+
+        Assert.Same(options, validatedOptions);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Validate_Throws_When_Topic_Name_Is_Missing(string? topicName)
+    {
+        var options = new MemoryBufferQueueOptions { TopicName = topicName };
+
+        var exception = Assert.Throws<ArgumentException>(() => options.Validate());
+
+        Assert.Equal("TopicName", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_Throws_When_Partition_Number_Is_Not_Positive(int partitionNumber)
+    {
+        var options = new MemoryBufferQueueOptions
+        {
+            TopicName = "test",
+            PartitionNumber = partitionNumber
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+
+        Assert.Equal("PartitionNumber", exception.ParamName);
+    }
+
+    [Fact]
+    public void Validate_Throws_When_Bounded_Capacity_Is_Zero()
+    {
+        var options = new MemoryBufferQueueOptions
+        {
+            TopicName = "test",
+            BoundedCapacity = 0
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+
+        Assert.Equal("BoundedCapacity", exception.ParamName);
+    }
+
+    [Fact]
+    public void Validate_Throws_When_Full_Mode_Is_Not_Supported()
+    {
+        var options = new MemoryBufferQueueOptions
+        {
+            TopicName = "test",
+            FullMode = (BufferQueueFullMode)int.MaxValue
+        };
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(() => options.Validate());
+
+        Assert.Equal("FullMode", exception.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary

- add a unified producer API with cancellation-aware single and batch writes
- add bounded Memory queue `Wait` and `Fail` full modes with FIFO weighted admission
- release bounded capacity from committed consumer progress and preserve late-group reads
- implement the unified API for MemoryMappedFile and validate options at registration/construction
- update samples, design docs, package READMEs, and benchmark results in English and Chinese

## Validation

- `dotnet format BufferQueue.slnx --verify-no-changes --no-restore`
- Release tests: BufferQueue 111/111 on net8.0 and net10.0
- Release tests: BufferQueue.MemoryMappedFile 96/96 on net8.0 and net10.0
- independent code review completed with no remaining findings

## Release

Intended for `v2.0.1`. Existing applications compiled against 2.0.0 should be rebuilt because `IBufferProducer<T>` method signatures now include cancellation tokens.